### PR TITLE
fix(specs): createCaller를 노출하여 빌드 오류 수정

### DIFF
--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -16,6 +16,7 @@
     "@next/third-parties": "^15.0.3",
     "@radix-ui/react-menubar": "^1.1.2",
     "@radix-ui/react-slot": "^1.1.0",
+    "@request/specs": "workspace:^",
     "@sentry/nextjs": "^8",
     "@sentry/utils": "^8.39.0",
     "@tanstack/react-query": "^5.59.16",
@@ -43,7 +44,6 @@
     "zod": "^3.23.8"
   },
   "devDependencies": {
-    "@request/specs": "workspace:^",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",

--- a/apps/client/src/shared/lib/trpc.ts
+++ b/apps/client/src/shared/lib/trpc.ts
@@ -1,10 +1,3 @@
-import { appRouter } from "@request/specs";
-import { initTRPC } from "@trpc/server";
+import { appRouter, createCaller } from "@request/specs";
 
-const t = initTRPC.context().create();
-
-const { createCallerFactory } = t;
-
-const createCaller = createCallerFactory(appRouter);
-
-export const caller = createCaller(appRouter);
+export const caller = createCaller({ baseUrl: "http://localhost:3000", user: null });

--- a/packages/specs/package.json
+++ b/packages/specs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@request/specs",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "shared types and schema",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/specs/src/index.ts
+++ b/packages/specs/src/index.ts
@@ -1,4 +1,5 @@
 import { TRPCError } from "@trpc/server";
+import { createCallerFactory } from "@trpc/server/unstable-core-do-not-import";
 import { humanId } from "human-id";
 import z from "zod";
 import { AssignmentFilterSchema, AssignmentPromptSchema } from "./schema/assignment.js";
@@ -217,6 +218,8 @@ export const TestSchema = z.object({ name: z.string(), });`,
 // https://trpc.io/docs/server/server-side-calls 참고하세용
 
 export type AppRouter = typeof appRouter;
+
+export const createCaller = t.createCallerFactory(appRouter);
 
 export * from "./schema/assignment.js";
 export * from "./schema/review.js";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,9 @@ importers:
       '@radix-ui/react-slot':
         specifier: ^1.1.0
         version: 1.1.0(@types/react@18.3.12)(react@19.0.0-rc-66855b96-20241106)
+      '@request/specs':
+        specifier: workspace:^
+        version: link:../../packages/specs
       '@sentry/nextjs':
         specifier: ^8
         version: 8.39.0(@opentelemetry/core@1.28.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.54.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.28.0(@opentelemetry/api@1.9.0))(next@15.0.3(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)(webpack@5.96.1)
@@ -141,9 +144,6 @@ importers:
         specifier: ^3.23.8
         version: 3.23.8
     devDependencies:
-      '@request/specs':
-        specifier: workspace:^
-        version: link:../../packages/specs
       '@types/node':
         specifier: ^20
         version: 20.17.6


### PR DESCRIPTION
<!-- PR 제목 한 번 확인해주세요!
브랜치 이름 + 주된 작업 요약
ex. feat/#1 프로젝트 세팅 -->

### **요약 (Summary)**

클라이언트에서 `createCallerFactory`, `createCaller`를 사용하여 타입 정의 오류로 인해 Docker ci가 깨지는 현상 발생
-> `@request/specs`에서 `createCaller`  함수를 노출하여 클라이언트에서 호출하여 mock API를 사용하기
+ `@request/specs`가 devDependencies로 정의되어 있었으나  zod schema 등의 사용이 필요함을 고려하면 dependencies로 이동함이 적절, Docker 빌드 과정에서 최적화를 위해 실행에 필요 없는 dependencies(예: devDependencies)는 자동으로 제외함으로 의존성 설정에 유의해주세요!!

### **배경 (Background)**

<!-- 프로젝트의 Context를 적습니다. 왜 이 기능을 만드는지, 동기는 무엇인지, 어떤 사용자 문제를 해결하려 하는지, 이전에 이런 시도가 있었는지, 있었다면 해결이 되었는지 등을 포함합니다.

> 다양한 탭을 사용하는 유저는 Segment에 따라 하단 탭의 노출 수와 사용 빈도가 다릅니다. 예를 들어, 20대와 30대의 추천 탭 노출 수 사이는 월 n만 정도입니다. 이러한 유저의 Segment에 맞춰 하단 탭 순서를 유저가 직접 커스텀할 수 있다면 뱅크샐러드가 개인화되었다고 인지할 수 있을 것입니다. -->

### **목표 (Goals)**

<!-- 예상 결과들을 Bullet Point 형태로 나열합니다. 이 목표들과 측정 가능한 임팩트들을 이용해 추후 이 프로젝트의 성공 여부를 평가합니다.

> Bottom Navigation의 순서를 유저가 편집할 수 있게 한다.앱을 껐다 켰을 시에도 유저가 편집한 순서대로 하단 탭을 보이게 한다. -->

### **이외 고려 사항들 (Other Considerations)**

<!-- 고려했었으나 하지 않기로 결정된 사항들을 적습니다. 이렇게 함으로써 이전에 논의되었던 주제가 다시 나오지 않도록 할 수 있고, 이미 논의되었던 내용이더라도 리뷰어들이 다시 살펴볼 수 있습니다.

> 앱 데이터 초기화 시에는 사용자가 커스텀했던 리스트를 모두 날리기로 했었으나, 기존 로직에서 앱 데이터 초기화 시에 로컬 관련 추가 핸들링이 없어 이 기능에서도 앱 데이터 초기화 때에 리스트를 날리는 등 추가적인 기능 구현을 하지 않기로 함. -->
