### PR TITLE
feat: `v1.auth.register` 엔드포인트 구현

### DIFF
--- a/apps/gasi/src/context.ts
+++ b/apps/gasi/src/context.ts
@@ -1,6 +1,5 @@
-import { type User, UserSchema } from "@request/specs";
 import type { CreateFastifyContextOptions } from "@trpc/server/adapters/fastify";
-import type { FastifyBaseLogger } from "fastify";
+import type { HydratedDocument } from "mongoose";
 import { server } from "./index.js";
 import { mUser } from "./model/index.js";
 
@@ -8,7 +7,7 @@ const defaultBaseUrl = process.env.CLIENT_BASE_URL ?? "http://localhost:3000";
 
 export const createContext = async (
   opts: CreateFastifyContextOptions,
-): Promise<{ baseUrl: string; user: User | null }> => {
+): Promise<{ baseUrl: string; user: HydratedDocument<typeof mUser.schema.obj> | null }> => {
   const referer = opts.req.headers.referer;
   let user = null;
   let baseUrl = defaultBaseUrl;
@@ -17,7 +16,7 @@ export const createContext = async (
     server.log.info(token);
     const doc = await mUser.findOne({ token });
     if (doc) {
-      user = UserSchema.parse(doc.toObject());
+      user = doc;
     }
   }
   if (referer) {

--- a/apps/gasi/src/routes/auth.ts
+++ b/apps/gasi/src/routes/auth.ts
@@ -18,4 +18,20 @@ export const register = p.input(RegisterUserRequestSchema).mutation(async ({ inp
     });
   if (ctx.user.registered)
     throw new TRPCError({ code: "CONFLICT", message: "이미 가입을 진행한 사용자입니다." });
+
+  const res = await ctx.user.updateOne({
+    name: input.name,
+    email: input.email,
+    registered: true,
+    prompt: {
+      fields: input.prompt.fields,
+      techs: input.prompt.techs,
+      companies: input.prompt.companies,
+    },
+  });
+  if (res.modifiedCount !== 1)
+    throw new TRPCError({
+      code: "INTERNAL_SERVER_ERROR",
+      message: "데이터베이스 등록 작업에 실패했습니다.",
+    });
 });

--- a/apps/gasi/src/routes/auth.ts
+++ b/apps/gasi/src/routes/auth.ts
@@ -1,4 +1,5 @@
 import { RegisterUserRequestSchema } from "@request/specs";
+import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 import { kakaoAuthorize } from "../auth/providers.js";
 import { p } from "../trpc.js";
@@ -9,4 +10,12 @@ export const kakao = p
     return await kakaoAuthorize(input.redirectUrl ?? `${ctx.baseUrl}/callback`, input.code);
   });
 
-export const register = p.input(RegisterUserRequestSchema).mutation(() => {});
+export const register = p.input(RegisterUserRequestSchema).mutation(async ({ input, ctx }) => {
+  if (!ctx.user)
+    throw new TRPCError({
+      code: "UNAUTHORIZED",
+      message: "토큰이 없거나 올바르지 않습니다. Authorization 헤더를 확인하세요.",
+    });
+  if (ctx.user.registered)
+    throw new TRPCError({ code: "CONFLICT", message: "이미 가입을 진행한 사용자입니다." });
+});


### PR DESCRIPTION
<!-- PR 제목 한 번 확인해주세요!
브랜치 이름 + 주된 작업 요약
ex. feat/#1 프로젝트 세팅 -->

### **요약 (Summary)**

사용자 온보딩 시 필요한 `v1.auth.register` 엔드포인트를 구현했습니다. `v1.auth.kakao` 응답에 registered: false 일 경우 이 엔드포인트에 요청을 보내 온보딩을 진행합니다.

참고: 요청 스키마 및 설명
```ts
export const RegisterUserRequestSchema = z.object({
  // 사용자 이름
  name: z.string(),
  // GitHub 이메일
  email: z.string().email(),
  // 희망직무, 기술, 기업
  prompt: AssignmentPromptSchema,
  // 학력은 빼먹었습니다... 알잘딱해주세용~
});
```

### **배경 (Background)**

<!-- 프로젝트의 Context를 적습니다. 왜 이 기능을 만드는지, 동기는 무엇인지, 어떤 사용자 문제를 해결하려 하는지, 이전에 이런 시도가 있었는지, 있었다면 해결이 되었는지 등을 포함합니다.

> 다양한 탭을 사용하는 유저는 Segment에 따라 하단 탭의 노출 수와 사용 빈도가 다릅니다. 예를 들어, 20대와 30대의 추천 탭 노출 수 사이는 월 n만 정도입니다. 이러한 유저의 Segment에 맞춰 하단 탭 순서를 유저가 직접 커스텀할 수 있다면 뱅크샐러드가 개인화되었다고 인지할 수 있을 것입니다. -->

### **목표 (Goals)**

<!-- 예상 결과들을 Bullet Point 형태로 나열합니다. 이 목표들과 측정 가능한 임팩트들을 이용해 추후 이 프로젝트의 성공 여부를 평가합니다.

> Bottom Navigation의 순서를 유저가 편집할 수 있게 한다.앱을 껐다 켰을 시에도 유저가 편집한 순서대로 하단 탭을 보이게 한다. -->

### **이외 고려 사항들 (Other Considerations)**

<!-- 고려했었으나 하지 않기로 결정된 사항들을 적습니다. 이렇게 함으로써 이전에 논의되었던 주제가 다시 나오지 않도록 할 수 있고, 이미 논의되었던 내용이더라도 리뷰어들이 다시 살펴볼 수 있습니다.

> 앱 데이터 초기화 시에는 사용자가 커스텀했던 리스트를 모두 날리기로 했었으나, 기존 로직에서 앱 데이터 초기화 시에 로컬 관련 추가 핸들링이 없어 이 기능에서도 앱 데이터 초기화 때에 리스트를 날리는 등 추가적인 기능 구현을 하지 않기로 함. -->
