### PR TITLE
feat(gasi): v1.user.me 엔드포인트

### DIFF
--- a/apps/gasi/src/auth/token.ts
+++ b/apps/gasi/src/auth/token.ts
@@ -1,6 +1,7 @@
-import type { AuthorizationResult, User } from "@request/specs";
+import type { AuthorizationResult } from "@request/specs";
 import { TRPCError } from "@trpc/server";
 import jwt from "jsonwebtoken";
+import type { HydratedDocument } from "mongoose";
 import { mUser } from "../model/index.js";
 
 const JWT_SECRET =
@@ -50,4 +51,20 @@ export const authorizeWith = async (
     code: "INTERNAL_SERVER_ERROR",
     message: "Cannot create an user. maybe request is malformed or database issue?",
   });
+};
+
+export const checkRegistered = (
+  user: HydratedDocument<typeof mUser.schema.obj> | null,
+): boolean => {
+  if (!user)
+    throw new TRPCError({
+      code: "UNAUTHORIZED",
+      message: "토큰이 없거나 올바르지 않습니다. Authorization 헤더를 확인하세요.",
+    });
+  if (!user.registered)
+    throw new TRPCError({
+      code: "FORBIDDEN",
+      message: "가입되지 않은 사용자는 사용할 수 없습니다.",
+    });
+  return true;
 };

--- a/apps/gasi/src/model/schema.ts
+++ b/apps/gasi/src/model/schema.ts
@@ -1,3 +1,12 @@
+import type {
+  Assignment,
+  AssignmentPromptSchema,
+  Review,
+  ReviewEntry,
+  ReviewScenario,
+  Submission,
+  User,
+} from "@request/specs";
 import { Schema } from "mongoose";
 
 const mAuthProviderSchema = new Schema({
@@ -5,13 +14,14 @@ const mAuthProviderSchema = new Schema({
   connectedAt: { type: Date },
 });
 
-export const mAssignmentPromptSchema = new Schema({
+export const mAssignmentPromptSchema = new Schema<AssignmentPromptSchema>({
   fields: { type: [String] },
   techs: { type: [String] },
   companies: { type: [String] },
 });
 
-export const mAssignmentSchema = new Schema({
+// biome-ignore lint/suspicious/noExplicitAny: no support native date type in mongoose
+export const mAssignmentSchema = new Schema<Assignment & { lastUpdated: any }>({
   id: { type: String, unique: true, required: true, index: true },
   name: { type: String, required: true },
   description: { type: String, required: true },
@@ -21,7 +31,8 @@ export const mAssignmentSchema = new Schema({
   lastUpdated: { type: Date, required: true, default: Date.now },
 });
 
-export const mSubmissionSchema = new Schema({
+// biome-ignore lint/suspicious/noExplicitAny: no support native date type in mongoose
+export const mSubmissionSchema = new Schema<Submission & { lastUpdated: any; expiredAt: any }>({
   id: { type: String, unique: true, required: true, index: true },
   assignmentId: { type: String, required: true, index: true },
   status: { type: String, default: "PREPARING" },
@@ -29,20 +40,20 @@ export const mSubmissionSchema = new Schema({
   expiredAt: { type: Date },
 });
 
-export const mReviewScenarioSchema = new Schema({
+export const mReviewScenarioSchema = new Schema<ReviewScenario>({
   id: { type: String, required: true },
   name: { type: String, required: true },
   result: { type: String, required: true },
   score: { type: Number },
 });
 
-export const mReviewSchema = new Schema({
+export const mReviewSchema = new Schema<Review>({
   id: { type: String, unique: true, required: true, index: true },
   status: { type: String, required: true },
   scenarios: { type: [mReviewScenarioSchema] },
 });
 
-export const mReviewEntrySchema = new Schema({
+export const mReviewEntrySchema = new Schema<ReviewEntry & { submissionId: string }>({
   submissionId: { type: String, required: true, index: true },
   name: { type: String, required: true },
   result: { type: String, required: true },
@@ -53,7 +64,7 @@ export const mReviewEntrySchema = new Schema({
   message: { type: String, required: true },
 });
 
-export const mUserSchema = new Schema({
+export const mUserSchema = new Schema<User & { token: string }>({
   token: { type: String, unique: true, required: true },
   name: { type: String },
   email: { type: String, unique: true, index: true, sparse: true },

--- a/apps/gasi/src/routes/user.ts
+++ b/apps/gasi/src/routes/user.ts
@@ -1,23 +1,7 @@
 import type { User } from "@request/specs";
+import { checkRegistered } from "../auth/token.js";
 import { p } from "../trpc.js";
 
-export const me = p.query(
-  (): User => ({
-    id: "673f25db6a52140e5bc47f75",
-    name: "구효민",
-    email: "hyomin@soongsil.ac.kr",
-    registered: true,
-    providers: {
-      kakao: {
-        uid: "230549202",
-        connectedAt: "2024-11-21T12:25:34.710Z",
-      },
-    },
-    submissions: [],
-    prompt: {
-      fields: ["프론트엔드", "서버/백엔드"],
-      techs: ["Spring Boot", "Rust"],
-      companies: ["kakao", "goorm"],
-    },
-  }),
-);
+export const me = p.query(({ ctx }): User => {
+  return checkRegistered(ctx.user);
+});


### PR DESCRIPTION
<!-- PR 제목 한 번 확인해주세요!
브랜치 이름 + 주된 작업 요약
ex. feat/#1 프로젝트 세팅 -->

### **요약 (Summary)**

<!-- 가장 먼저 테크 스펙을 세 줄 내외로 정리합니다. 테크 스펙의 제안 전체에 대해 누가/무엇을/언제/어디서/왜를 간략하면서도 명확하게 적습니다.

> Bottom Navigation 영역(하단 탭)을 유저가 원하는 순서로 커스텀할 수 있게 합니다. 서버에 순서 정렬 및 저장 API를 요청할 수 없으므로, 순서를 로컬에 저장하고 불러옵니다. -->

### **배경 (Background)**

<!-- 프로젝트의 Context를 적습니다. 왜 이 기능을 만드는지, 동기는 무엇인지, 어떤 사용자 문제를 해결하려 하는지, 이전에 이런 시도가 있었는지, 있었다면 해결이 되었는지 등을 포함합니다.

> 다양한 탭을 사용하는 유저는 Segment에 따라 하단 탭의 노출 수와 사용 빈도가 다릅니다. 예를 들어, 20대와 30대의 추천 탭 노출 수 사이는 월 n만 정도입니다. 이러한 유저의 Segment에 맞춰 하단 탭 순서를 유저가 직접 커스텀할 수 있다면 뱅크샐러드가 개인화되었다고 인지할 수 있을 것입니다. -->

### **목표 (Goals)**

<!-- 예상 결과들을 Bullet Point 형태로 나열합니다. 이 목표들과 측정 가능한 임팩트들을 이용해 추후 이 프로젝트의 성공 여부를 평가합니다.

> Bottom Navigation의 순서를 유저가 편집할 수 있게 한다.앱을 껐다 켰을 시에도 유저가 편집한 순서대로 하단 탭을 보이게 한다. -->

### **이외 고려 사항들 (Other Considerations)**

<!-- 고려했었으나 하지 않기로 결정된 사항들을 적습니다. 이렇게 함으로써 이전에 논의되었던 주제가 다시 나오지 않도록 할 수 있고, 이미 논의되었던 내용이더라도 리뷰어들이 다시 살펴볼 수 있습니다.

> 앱 데이터 초기화 시에는 사용자가 커스텀했던 리스트를 모두 날리기로 했었으나, 기존 로직에서 앱 데이터 초기화 시에 로컬 관련 추가 핸들링이 없어 이 기능에서도 앱 데이터 초기화 때에 리스트를 날리는 등 추가적인 기능 구현을 하지 않기로 함. -->
