### PR TITLE
feat(client): 카카오 로그인 API 연동

### DIFF
--- a/apps/client/src/app/callback/page.tsx
+++ b/apps/client/src/app/callback/page.tsx
@@ -1,0 +1,5 @@
+import CallbackPage from "@/pages/callback/callback-page";
+
+export default function Callback() {
+  return <CallbackPage />;
+}

--- a/apps/client/src/features/callback/types/global.d.ts
+++ b/apps/client/src/features/callback/types/global.d.ts
@@ -1,0 +1,12 @@
+declare global {
+    interface Window {
+      Kakao: {
+        init: (key: string) => void;
+        isInitialized: () => boolean;
+        Auth: {
+          authorize: ({ redirectUri }: { redirectUri: string }) => void;
+        };
+      };
+    }
+  }
+  export {};

--- a/apps/client/src/features/onboarding/ui/auth.tsx
+++ b/apps/client/src/features/onboarding/ui/auth.tsx
@@ -13,7 +13,11 @@ export default function Auth() {
     navigate.push("/");
   };
 
-  const onClickKakaoLogin = () => {};
+  const onClickKakaoLogin = () => {
+    window.Kakao.Auth.authorize({
+      redirectUri: process.env.NEXT_PUBLIC_KAKAO_REDIRECT_URI as string,
+    });
+  };
   return (
     <Flex direction="col" gap="2" alignItems="center" className="mt-5">
       <Button

--- a/apps/client/src/pages/callback/callback-page.tsx
+++ b/apps/client/src/pages/callback/callback-page.tsx
@@ -1,3 +1,71 @@
-export default async function CallbackPage() {
-  return <div>Callback</div>;
+"use client";
+
+import { trpc } from "@/shared/api/trpc";
+import { setCookie } from "@/shared/lib/cookie";
+import Typography from "@/shared/ui/common/typography/typography";
+import Flex from "@/shared/ui/wrapper/flex/flex";
+import { Loader2 } from "lucide-react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useEffect } from "react";
+
+export default function CallbackPage() {
+  const searchParams = useSearchParams();
+  const code = searchParams?.get("code") || "";
+  const router = useRouter();
+  const { data, isLoading, isError, isSuccess } = trpc.v1.auth.kakao.useQuery(
+    { code },
+    { enabled: !!code },
+  );
+
+  const handleRedirectToHome = () => {
+    router.replace("/");
+  };
+
+  const handleRedirectToOnboardingProfile = () => {
+    router.replace("/onboarding/profile");
+  };
+
+  const textByLoading = isLoading ? "로그인 중..." : isError ? "로그인 실패" : "로그인 성공!";
+  const textByError = isError
+    ? "관리자에게 문의 해주세요."
+    : data?.registered
+      ? "메인 페이지로 이동합니다."
+      : "ReQuest에 오신 것을 환영합니다!";
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
+  useEffect(() => {
+    if (!code) {
+      handleRedirectToHome();
+    }
+  }, [code, router]);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
+  useEffect(() => {
+    if (!isLoading) {
+      if (isSuccess) {
+        setCookie("accessToken", data?.accessToken);
+      }
+      setTimeout(() => {
+        if (isError || data?.registered) {
+          return handleRedirectToHome();
+        }
+        handleRedirectToOnboardingProfile();
+      }, 2000);
+    }
+  }, [isLoading]);
+
+  return (
+    <Flex as="main" direction="col" className="h-screen justify-center items-center gap-10">
+      <Typography as="p" className="text-primary text-5xl font-bold">
+        {textByLoading}
+      </Typography>
+      {isLoading ? (
+        <Loader2 className="w-20 h-20 animate-spin" />
+      ) : (
+        <Typography as="p" className="text-center text-3xl font-bold">
+          {textByError}
+        </Typography>
+      )}
+    </Flex>
+  );
 }

--- a/apps/client/src/pages/callback/callback-page.tsx
+++ b/apps/client/src/pages/callback/callback-page.tsx
@@ -1,0 +1,3 @@
+export default async function CallbackPage() {
+  return <div>Callback</div>;
+}

--- a/apps/client/src/pages/callback/callback-page.tsx
+++ b/apps/client/src/pages/callback/callback-page.tsx
@@ -41,21 +41,21 @@ export default function CallbackPage() {
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   useEffect(() => {
-    if (!isLoading) {
-      if (isSuccess) {
-        setCookie("accessToken", data?.accessToken);
-      }
-      setTimeout(() => {
-        if (isError || data?.registered) {
-          return handleRedirectToHome();
-        }
-        handleRedirectToOnboardingProfile();
-      }, 2000);
-    }
+    // if (!isLoading) {
+    //   if (isSuccess) {
+    //     setCookie("accessToken", data?.accessToken);
+    //   }
+    //   setTimeout(() => {
+    //     if (isError || data?.registered) {
+    //       return handleRedirectToHome();
+    //     }
+    //     handleRedirectToOnboardingProfile();
+    //   }, 2000);
+    // }
   }, [isLoading]);
 
   return (
-    <Flex as="main" direction="col" className="h-screen justify-center items-center gap-10">
+    <Flex as="main" direction="col" className="h-fit-height justify-center items-center gap-10">
       <Typography as="p" className="text-primary text-5xl font-bold">
         {textByLoading}
       </Typography>

--- a/apps/client/src/pages/callback/callback-page.tsx
+++ b/apps/client/src/pages/callback/callback-page.tsx
@@ -41,17 +41,17 @@ export default function CallbackPage() {
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   useEffect(() => {
-    // if (!isLoading) {
-    //   if (isSuccess) {
-    //     setCookie("accessToken", data?.accessToken);
-    //   }
-    //   setTimeout(() => {
-    //     if (isError || data?.registered) {
-    //       return handleRedirectToHome();
-    //     }
-    //     handleRedirectToOnboardingProfile();
-    //   }, 2000);
-    // }
+    if (!isLoading) {
+      if (isSuccess) {
+        setCookie("accessToken", data?.accessToken);
+      }
+      setTimeout(() => {
+        if (isError || data?.registered) {
+          return handleRedirectToHome();
+        }
+        handleRedirectToOnboardingProfile();
+      }, 2000);
+    }
   }, [isLoading]);
 
   return (

--- a/apps/client/src/pages/onboarding-page.tsx
+++ b/apps/client/src/pages/onboarding-page.tsx
@@ -7,7 +7,13 @@ import Image from "next/image";
 
 export default function OnboardingPage() {
   return (
-    <Flex as="section" justifyContent="center" gap="24" className="h-screen">
+    <Flex
+      as="section"
+      justifyContent="center"
+      gap="24"
+      className="h-fit-height
+    "
+    >
       <Flex className="font-bold justify-center items-center">
         <div className="space-y-6">
           <Image src={logoSvg} width={250} height={76} alt="ReQuest 로고 이미지" />

--- a/apps/client/src/shared/lib/cookie.ts
+++ b/apps/client/src/shared/lib/cookie.ts
@@ -1,0 +1,9 @@
+"use server";
+
+import type { NextApiRequestCookies } from "next/dist/server/api-utils";
+import { cookies } from "next/headers";
+
+export const setCookie = async (key: string, value: string, options?: NextApiRequestCookies) => {
+  const cookieStore = await cookies();
+  cookieStore.set(key, value, options);
+};

--- a/apps/client/src/widgets/script-provider.tsx
+++ b/apps/client/src/widgets/script-provider.tsx
@@ -1,9 +1,11 @@
 import { GoogleAnalytics } from "@next/third-parties/google";
+import KakaoScript from "./ui/kakao-script";
 
 export default function ScriptProvider({ children }: { children: React.ReactNode }) {
   return (
     <>
       <GoogleAnalytics gaId="G-NQ66NY0NXH" />
+      <KakaoScript />
       {children}
     </>
   );

--- a/apps/client/src/widgets/ui/kakao-script.tsx
+++ b/apps/client/src/widgets/ui/kakao-script.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import Script from "next/script";
+
+export default function KakaoScript() {
+  const handleKakaoInit = () => {
+    window.Kakao.init(process.env.NEXT_PUBLIC_KAKAO_CLIENT_ID as string);
+  };
+  return (
+    <Script
+      src="https://t1.kakaocdn.net/kakao_js_sdk/2.7.3/kakao.min.js"
+      integrity="sha384-kLbo2SvoNtOFiniJ1EQ9o2iDA8i3xp+O6Cns+L5cd4RsOJfl+43z5pvieT2ayq3C"
+      crossOrigin="anonymous"
+      onLoad={handleKakaoInit}
+    />
+  );
+}

--- a/apps/client/tailwind.config.ts
+++ b/apps/client/tailwind.config.ts
@@ -27,6 +27,9 @@ const config: Config = {
         md: "calc(var(--radius) - 2px)",
         sm: "calc(var(--radius) - 4px)",
       },
+      height: {
+        "fit-height": "calc(100vh - 233px)",
+      },
     },
   },
   plugins: [require("tailwindcss-animate")],


### PR DESCRIPTION
<!-- PR 제목 한 번 확인해주세요!
브랜치 이름 + 주된 작업 요약
ex. feat/#1 프로젝트 세팅 -->

### **요약 (Summary)**

<!-- 가장 먼저 테크 스펙을 세 줄 내외로 정리합니다. 테크 스펙의 제안 전체에 대해 누가/무엇을/언제/어디서/왜를 간략하면서도 명확하게 적습니다.

> Bottom Navigation 영역(하단 탭)을 유저가 원하는 순서로 커스텀할 수 있게 합니다. 서버에 순서 정렬 및 저장 API를 요청할 수 없으므로, 순서를 로컬에 저장하고 불러옵니다. -->

카카오 로그인 API 연동했습니다.

### **배경 (Background)**

<!-- 프로젝트의 Context를 적습니다. 왜 이 기능을 만드는지, 동기는 무엇인지, 어떤 사용자 문제를 해결하려 하는지, 이전에 이런 시도가 있었는지, 있었다면 해결이 되었는지 등을 포함합니다.

> 다양한 탭을 사용하는 유저는 Segment에 따라 하단 탭의 노출 수와 사용 빈도가 다릅니다. 예를 들어, 20대와 30대의 추천 탭 노출 수 사이는 월 n만 정도입니다. 이러한 유저의 Segment에 맞춰 하단 탭 순서를 유저가 직접 커스텀할 수 있다면 뱅크샐러드가 개인화되었다고 인지할 수 있을 것입니다. -->

### **목표 (Goals)**

<!-- 예상 결과들을 Bullet Point 형태로 나열합니다. 이 목표들과 측정 가능한 임팩트들을 이용해 추후 이 프로젝트의 성공 여부를 평가합니다.

> Bottom Navigation의 순서를 유저가 편집할 수 있게 한다.앱을 껐다 켰을 시에도 유저가 편집한 순서대로 하단 탭을 보이게 한다. -->

### **이외 고려 사항들 (Other Considerations)**

<!-- 고려했었으나 하지 않기로 결정된 사항들을 적습니다. 이렇게 함으로써 이전에 논의되었던 주제가 다시 나오지 않도록 할 수 있고, 이미 논의되었던 내용이더라도 리뷰어들이 다시 살펴볼 수 있습니다.

> 앱 데이터 초기화 시에는 사용자가 커스텀했던 리스트를 모두 날리기로 했었으나, 기존 로직에서 앱 데이터 초기화 시에 로컬 관련 추가 핸들링이 없어 이 기능에서도 앱 데이터 초기화 때에 리스트를 날리는 등 추가적인 기능 구현을 하지 않기로 함. -->
