### PR TITLE
fix(client): trpc로 인한 빌드 안되는 오류 해결

### DIFF
--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -54,8 +54,6 @@
     "typescript": "^5"
   },
   "msw": {
-    "workerDirectory": [
-      "public"
-    ]
+    "workerDirectory": ["public"]
   }
 }

--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -21,7 +21,7 @@
     "@sentry/utils": "^8.39.0",
     "@tanstack/react-query": "^5.59.16",
     "@trpc/client": "^11.0.0-rc.638",
-    "@trpc/next": "^11.0.0-rc.638",
+    "@trpc/next": "11.0.0-rc.638",
     "@trpc/react-query": "^11.0.0-rc.638",
     "@trpc/server": "^11.0.0-rc.638",
     "@types/mdx": "^2.0.13",
@@ -54,6 +54,8 @@
     "typescript": "^5"
   },
   "msw": {
-    "workerDirectory": ["public"]
+    "workerDirectory": [
+      "public"
+    ]
   }
 }

--- a/apps/client/src/pages/callback/callback-page.tsx
+++ b/apps/client/src/pages/callback/callback-page.tsx
@@ -8,7 +8,7 @@ import { Loader2 } from "lucide-react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useEffect } from "react";
 
-export default function CallbackPage() {
+const CallbackPage = () => {
   const searchParams = useSearchParams();
   const code = searchParams?.get("code") || "";
   const router = useRouter();
@@ -68,4 +68,6 @@ export default function CallbackPage() {
       )}
     </Flex>
   );
-}
+};
+
+export default trpc.withTRPC(CallbackPage);

--- a/apps/client/src/shared/api/trpc.ts
+++ b/apps/client/src/shared/api/trpc.ts
@@ -1,4 +1,17 @@
 import type { AppRouter } from "@request/specs";
-import { createTRPCReact } from "@trpc/react-query";
+import { httpBatchLink } from "@trpc/client";
+import { createTRPCNext } from "@trpc/next";
 
-export const trpc = createTRPCReact<AppRouter>();
+export const trpc = createTRPCNext<AppRouter>({
+  config(opts) {
+    return {
+      ...opts,
+      links: [
+        httpBatchLink({
+          url: "/trpc",
+          // You can pass any HTTP headers you wish here
+        }),
+      ],
+    };
+  },
+});

--- a/apps/client/src/widgets/query-provider.tsx
+++ b/apps/client/src/widgets/query-provider.tsx
@@ -1,23 +1,11 @@
 "use client";
 
-import { trpc } from "@/shared/api/trpc";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { httpBatchLink } from "@trpc/client";
 import type { ReactNode } from "react";
 import { useEffect, useRef, useState } from "react";
 
 const QueryProvider = ({ children }: { children: ReactNode }) => {
   const [queryClient] = useState(() => new QueryClient());
-  const [trpcClient] = useState(() =>
-    trpc.createClient({
-      links: [
-        httpBatchLink({
-          url: "/trpc",
-          // You can pass any HTTP headers you wish here
-        }),
-      ],
-    }),
-  );
 
   const [isMocking, setIsMocking] = useState(false);
   const isWorkerStarted = useRef(false);
@@ -41,11 +29,7 @@ const QueryProvider = ({ children }: { children: ReactNode }) => {
     return null;
   }
 
-  return (
-    <trpc.Provider client={trpcClient} queryClient={queryClient}>
-      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>{" "}
-    </trpc.Provider>
-  );
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
 };
 
 export default QueryProvider;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,7 +81,7 @@ importers:
         specifier: ^11.0.0-rc.638
         version: 11.0.0-rc.638(@trpc/server@11.0.0-rc.638(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106))
       '@trpc/next':
-        specifier: ^11.0.0-rc.638
+        specifier: 11.0.0-rc.638
         version: 11.0.0-rc.638(tcrg466klhukbonxzvuyyiioca)
       '@trpc/react-query':
         specifier: ^11.0.0-rc.638


### PR DESCRIPTION
<!-- PR 제목 한 번 확인해주세요!
브랜치 이름 + 주된 작업 요약
ex. feat/#1 프로젝트 세팅 -->

### **요약 (Summary)**

<!-- 가장 먼저 테크 스펙을 세 줄 내외로 정리합니다. 테크 스펙의 제안 전체에 대해 누가/무엇을/언제/어디서/왜를 간략하면서도 명확하게 적습니다.

> Bottom Navigation 영역(하단 탭)을 유저가 원하는 순서로 커스텀할 수 있게 합니다. 서버에 순서 정렬 및 저장 API를 요청할 수 없으므로, 순서를 로컬에 저장하고 불러옵니다. -->

trpc로 인한 빌드 안되는 오류 해결했습니다.

### **배경 (Background)**

<!-- 프로젝트의 Context를 적습니다. 왜 이 기능을 만드는지, 동기는 무엇인지, 어떤 사용자 문제를 해결하려 하는지, 이전에 이런 시도가 있었는지, 있었다면 해결이 되었는지 등을 포함합니다.

> 다양한 탭을 사용하는 유저는 Segment에 따라 하단 탭의 노출 수와 사용 빈도가 다릅니다. 예를 들어, 20대와 30대의 추천 탭 노출 수 사이는 월 n만 정도입니다. 이러한 유저의 Segment에 맞춰 하단 탭 순서를 유저가 직접 커스텀할 수 있다면 뱅크샐러드가 개인화되었다고 인지할 수 있을 것입니다. -->

withTRPC로 감싸지 않은 컴포넌트가 빌드되지 않는 오류를 해결하기 위해 진행하게 되었습니다.

### **목표 (Goals)**

<!-- 예상 결과들을 Bullet Point 형태로 나열합니다. 이 목표들과 측정 가능한 임팩트들을 이용해 추후 이 프로젝트의 성공 여부를 평가합니다.

> Bottom Navigation의 순서를 유저가 편집할 수 있게 한다.앱을 껐다 켰을 시에도 유저가 편집한 순서대로 하단 탭을 보이게 한다. -->

### **이외 고려 사항들 (Other Considerations)**

<!-- 고려했었으나 하지 않기로 결정된 사항들을 적습니다. 이렇게 함으로써 이전에 논의되었던 주제가 다시 나오지 않도록 할 수 있고, 이미 논의되었던 내용이더라도 리뷰어들이 다시 살펴볼 수 있습니다.

> 앱 데이터 초기화 시에는 사용자가 커스텀했던 리스트를 모두 날리기로 했었으나, 기존 로직에서 앱 데이터 초기화 시에 로컬 관련 추가 핸들링이 없어 이 기능에서도 앱 데이터 초기화 때에 리스트를 날리는 등 추가적인 기능 구현을 하지 않기로 함. -->

클라이언트 컴포넌트는 컴포넌트 형식을 아래와 같이 따라야 합니다.
```typescript
const SomeComponent = () => {
  ...
}

export default trpc.withTRPC(SomeComponent)
```