### PR TITLE
feat(gasi): `v1.submission` 엔드포인트 구현

### DIFF
--- a/apps/gasi/src/model/schema.ts
+++ b/apps/gasi/src/model/schema.ts
@@ -31,11 +31,15 @@ export const mAssignmentSchema = new Schema<Assignment & { lastUpdated: any }>({
   lastUpdated: { type: Date, required: true, default: Date.now },
 });
 
-// biome-ignore lint/suspicious/noExplicitAny: no support native date type in mongoose
-export const mSubmissionSchema = new Schema<Submission & { lastUpdated: any; expiredAt: any }>({
+export const mSubmissionSchema = new Schema<
+  // biome-ignore lint/suspicious/noExplicitAny: no support native date type in mongoose
+  Submission & { userId: any; lastUpdated: any; expiredAt: any }
+>({
   id: { type: String, unique: true, required: true, index: true },
+  userId: { type: Schema.Types.ObjectId, ref: "User", required: true, index: true },
   assignmentId: { type: String, required: true, index: true },
   status: { type: String, default: "PREPARING" },
+  repoUrl: { type: String },
   lastUpdated: { type: Date, required: true, default: Date.now },
   expiredAt: { type: Date },
 });
@@ -71,6 +75,6 @@ export const mUserSchema = new Schema<User & { token: string }>({
   registered: { type: Boolean, default: false },
   providers: { type: Map, of: mAuthProviderSchema },
   lastGeneratedAssignment: { type: String },
-  submissions: { type: [{ type: Schema.Types.ObjectId, ref: "Submission" }] },
+  submissions: { type: [{ type: String, ref: "Submission" }] },
   prompt: { type: mAssignmentPromptSchema },
 });

--- a/apps/gasi/src/routes/submission.ts
+++ b/apps/gasi/src/routes/submission.ts
@@ -10,12 +10,13 @@ import {
 } from "@request/specs";
 import { humanId } from "human-id";
 import { z } from "zod";
-import { createMockReviewEntry } from "../mockUtils.js";
+import { checkRegistered } from "../auth/token.js";
 import { p } from "../trpc.js";
 
 export const init = p.input(SubmissionInitSchema).mutation(
   (): Submission => ({
     id: humanId({ separator: "-", capitalize: false }),
+    userId: "6740940e8e20d5e1b2231d72",
     assignmentId: humanId({ separator: "-", capitalize: false }),
     status: "PREPARING",
     lastUpdated: new Date().toISOString(),
@@ -57,15 +58,12 @@ export const TestSchema = z.object({ name: z.string(), });`,
   }),
 );
 
-export const reviewEntries = p.input(ReviewFilterSchema).query((): ReviewEntry[] => {
-  return [
-    ...Array(5)
-      .fill(1)
-      .map((_, i) => createMockReviewEntry(`${i}번 채점 항목`, "summary", undefined, undefined)),
-    createMockReviewEntry("파일 채점 항목", "lint", "src/index.js", undefined),
-    createMockReviewEntry("라인 채점 항목", "lint", "src/index.js", [10, 13]),
-  ];
-});
+export const reviewEntries = p
+  .input(ReviewFilterSchema)
+  .query(async ({ input, ctx }): Promise<ReviewEntry[]> => {
+    const user = checkRegistered(ctx.user);
+    const submissions = ct;
+  });
 
 export const review = p.input(z.object({ id: z.string() })).query(
   ({ input }): Omit<Review, "entries"> => ({

--- a/apps/gasi/src/routes/submission.ts
+++ b/apps/gasi/src/routes/submission.ts
@@ -1,32 +1,75 @@
 import {
   type Review,
   type ReviewEntry,
+  ReviewEntrySchema,
   type ReviewFile,
   type ReviewFileTree,
   ReviewFilterSchema,
+  ReviewSchema,
   type Submission,
   SubmissionFileRequestSchema,
   SubmissionInitSchema,
+  SubmissionSchema,
 } from "@request/specs";
+import { TRPCError } from "@trpc/server";
 import { humanId } from "human-id";
 import { z } from "zod";
 import { checkRegistered } from "../auth/token.js";
+import { mReview, mReviewEntry, mSubmission } from "../model/index.js";
 import { p } from "../trpc.js";
 
-export const init = p.input(SubmissionInitSchema).mutation(
-  (): Submission => ({
-    id: humanId({ separator: "-", capitalize: false }),
-    userId: "6740940e8e20d5e1b2231d72",
-    assignmentId: humanId({ separator: "-", capitalize: false }),
-    status: "PREPARING",
-    lastUpdated: new Date().toISOString(),
-    expiredAt: null,
-  }),
-);
+export const init = p
+  .input(SubmissionInitSchema)
+  .mutation(async ({ input, ctx }): Promise<Submission> => {
+    const user = checkRegistered(ctx.user);
+    const ongoingSubmission = await mSubmission.findOne({
+      userId: user.id,
+      status: { $in: ["PREPARING", "STARTED", "SUBMITTED", "REVIEWING"] },
+    });
+    if (ongoingSubmission)
+      throw new TRPCError({
+        code: "TOO_MANY_REQUESTS",
+        message:
+          "이미 진행중인 제출물이 있습니다. 과제 제출 및 채점을 완료하거나 취소한 뒤 다시 시도하세요.",
+      });
+    const newDoc = new mSubmission();
+    newDoc.id = humanId({ separator: "-", capitalize: false });
+    newDoc.userId = user.id;
+    newDoc.assignmentId = input.assignmentId;
+    newDoc.lastUpdated = new Date();
+    await newDoc.save();
+    const docObj = newDoc.toObject();
+    const res = {
+      ...docObj,
+      lastUpdated: docObj.lastUpdated.toISOString(),
+      expiredAt: docObj.expiredAt?.toISOString() ?? null,
+    };
+    return SubmissionSchema.parse(res);
+  });
 
-export const cancel = p.input(z.object({ id: z.string() })).mutation((): string => {
-  return humanId({ separator: "-", capitalize: false });
-});
+export const cancel = p
+  .input(z.object({ id: z.string() }))
+  .mutation(async ({ input, ctx }): Promise<string> => {
+    const user = checkRegistered(ctx.user);
+    if (!user.submissions.includes(input.id))
+      throw new TRPCError({ code: "NOT_FOUND", message: "제출물을 찾을 수 없습니다." });
+    const ongoingSubmission = await mSubmission.findOneAndUpdate(
+      {
+        userId: user.id,
+        status: { $in: ["PREPARING", "STARTED", "SUBMITTED", "REVIEWING"] },
+      },
+      {
+        status: "CANCELED",
+      },
+    );
+    if (!ongoingSubmission)
+      throw new TRPCError({
+        code: "BAD_REQUEST",
+        message: `주어진 id ${input.id}가 진행중인 제출물이 아닙니다.`,
+      });
+    // TODO: Inform related services(GitHub, AGI) that user canceled submission
+    return ongoingSubmission.id;
+  });
 
 export const files = p.input(z.object({ id: z.string() })).query((): ReviewFileTree[] => [
   {
@@ -58,29 +101,29 @@ export const TestSchema = z.object({ name: z.string(), });`,
   }),
 );
 
+export const review = p
+  .input(z.object({ id: z.string() }))
+  .query(async ({ input, ctx }): Promise<Omit<Review, "entries">> => {
+    const user = checkRegistered(ctx.user);
+    if (!user.submissions.includes(input.id))
+      throw new TRPCError({ code: "NOT_FOUND", message: "제출물을 찾을 수 없습니다." });
+    const review = await mReview.findOne({ id: input.id });
+    if (!review)
+      throw new TRPCError({
+        code: "NOT_FOUND",
+        message: "리뷰 데이터를 찾을 수 없습니다. 제출물의 상태를 확인하세요.",
+      });
+    const res = review.toObject();
+    return ReviewSchema.omit({ entries: true }).parse(res);
+  });
+
 export const reviewEntries = p
   .input(ReviewFilterSchema)
   .query(async ({ input, ctx }): Promise<ReviewEntry[]> => {
     const user = checkRegistered(ctx.user);
-    const submissions = ct;
+    if (!user.submissions.includes(input.id))
+      throw new TRPCError({ code: "NOT_FOUND", message: "제출물을 찾을 수 없습니다." });
+    const reviewEntries = await mReviewEntry.find({ ...input });
+    const result: ReviewEntry[] = reviewEntries.map((doc) => doc.toObject());
+    return z.array(ReviewEntrySchema).parse(result);
   });
-
-export const review = p.input(z.object({ id: z.string() })).query(
-  ({ input }): Omit<Review, "entries"> => ({
-    id: input.id,
-    status: "DONE",
-    scenarios: [
-      {
-        id: "summary",
-        name: "종합 점수",
-        result: "GOOD",
-        score: 83,
-      },
-      {
-        id: "lint",
-        name: "기본 코드 스타일",
-        result: "FAIL",
-      },
-    ],
-  }),
-);

--- a/packages/specs/src/index.ts
+++ b/packages/specs/src/index.ts
@@ -38,6 +38,7 @@ const createMockAssignment = (id: string, name: string) => ({
 });
 
 const createMockReviewEntry = (
+  submissionId: string,
   name: string,
   scenario: string,
   path: string | undefined,
@@ -46,6 +47,7 @@ const createMockReviewEntry = (
   const score = Math.floor(Math.random() * 100);
   const result = Math.floor(score / 50);
   return {
+    submissionId,
     name,
     scenario,
     result: ["FAIL", "NEUTRAL", "GOOD"][result] as ReviewResult,
@@ -184,12 +186,12 @@ export const TestSchema = z.object({ name: z.string(), });`,
       // 요청한 범위 내의 모든 리뷰 내용을 반환합니다.
       reviewEntries: p
         .input(ReviewFilterSchema)
-        .query((): ReviewEntry[] => [
+        .query(({ input }): ReviewEntry[] => [
           ...Array(5).map((_, i) =>
-            createMockReviewEntry(`${i}번 채점 항목`, "summary", undefined, undefined),
+            createMockReviewEntry(input.id, `${i}번 채점 항목`, "summary", undefined, undefined),
           ),
-          createMockReviewEntry("파일 채점 항목", "lint", "src/index.js", undefined),
-          createMockReviewEntry("라인 채점 항목", "lint", "src/index.js", [10, 13]),
+          createMockReviewEntry(input.id, "파일 채점 항목", "lint", "src/index.js", undefined),
+          createMockReviewEntry(input.id, "라인 채점 항목", "lint", "src/index.js", [10, 13]),
         ]),
       // 리뷰의 기본 정보를 반환합니다.
       review: p.input(z.object({ id: z.string() })).query(

--- a/packages/specs/src/index.ts
+++ b/packages/specs/src/index.ts
@@ -1,5 +1,4 @@
 import { TRPCError } from "@trpc/server";
-import { createCallerFactory } from "@trpc/server/unstable-core-do-not-import";
 import { humanId } from "human-id";
 import z from "zod";
 import { AssignmentFilterSchema, AssignmentPromptSchema } from "./schema/assignment.js";
@@ -141,6 +140,7 @@ export const appRouter = t.router({
       init: p.input(SubmissionInitSchema).mutation(
         (): Submission => ({
           id: humanId({ separator: "-", capitalize: false }),
+          userId: "6740940e8e20d5e1b2231d72",
           assignmentId: humanId({ separator: "-", capitalize: false }),
           status: "PREPARING",
           lastUpdated: new Date().toISOString(),

--- a/packages/specs/src/schema/review.ts
+++ b/packages/specs/src/schema/review.ts
@@ -23,6 +23,7 @@ export const ReviewScenarioSchema = z.object({
 });
 
 export const ReviewEntrySchema = z.object({
+  submissionId: z.string(),
   name: z.string(),
   result: ReviewResultSchema,
   score: z.number().max(100).optional(),

--- a/packages/specs/src/schema/review.ts
+++ b/packages/specs/src/schema/review.ts
@@ -41,7 +41,7 @@ export const ReviewSchema = z.object({
 
 export const ReviewFilterSchema = z.object({
   id: z.string(),
-  scenario: z.string().default("summary"),
+  scenario: z.string().optional().default("summary"),
   path: z.string().optional(),
 });
 

--- a/packages/specs/src/schema/submission.ts
+++ b/packages/specs/src/schema/submission.ts
@@ -16,9 +16,11 @@ export const SubmissionStatusSchema = z.enum([
 
 export const SubmissionSchema = z.object({
   id: z.string(),
+  userId: z.string(),
   assignmentId: z.string(),
   status: SubmissionStatusSchema,
   lastUpdated: z.string().datetime(),
+  repoUrl: z.string().optional(),
   expiredAt: z.string().datetime().nullable(),
 });
 

--- a/packages/specs/src/schema/submission.ts
+++ b/packages/specs/src/schema/submission.ts
@@ -24,7 +24,9 @@ export const SubmissionSchema = z.object({
   expiredAt: z.string().datetime().nullable(),
 });
 
-export const SubmissionInitSchema = z.object({});
+export const SubmissionInitSchema = z.object({
+  assignmentId: z.string(),
+});
 
 export const SubmissionFileRequestSchema = z.object({
   id: z.string(),

--- a/packages/specs/src/schema/user.ts
+++ b/packages/specs/src/schema/user.ts
@@ -1,6 +1,5 @@
 import { z } from "zod";
 import { AssignmentPromptSchema } from "./assignment.js";
-import { SubmissionSchema } from "./submission.js";
 
 export type User = z.infer<typeof UserSchema>;
 export type RegisteredUser = z.infer<typeof RegisteredUserSchema>;
@@ -26,7 +25,7 @@ export const UserSchema = z.object({
       .optional(),
   }),
   lastGeneratedAssignment: z.string().optional(),
-  submissions: z.array(SubmissionSchema),
+  submissions: z.array(z.string()),
   prompt: AssignmentPromptSchema.optional(),
 });
 


### PR DESCRIPTION
> [!IMPORTANT]
> 확인하셨으면 리뷰해 주시고, FE 두 분 다 리뷰되었으면 마지막 리뷰하신 분이 머지해주세요.

### **요약 (Summary)**

`v1.submission` 아래의 엔드포인트를 `v1.submission.file`, `v1.submission.files`를 제외하고 구현했습니다.

구현된 엔드포인트
- `v1.submission.init`
- `v1.submission.cancel`
- `v1.submission.review`
- `v1.submission.reviewEntries`

# 주요 변경사항(BREAKING CHANGES)
몇 가지 빠진 데이터가 있어 추가하였고, User의 데이터 형태가 변경되었습니다.

**UserSchema**
```diff
export const UserSchema = z.object({
  id: z.string(),
  name: z.string().optional(),
  email: z.string().email().optional(),
  registered: z.boolean().default(false),
  providers: z.object({
    kakao: z
      .object({
        uid: z.string(),
        connectedAt: z.string().datetime(),
      })
      .optional(),
  }),
  lastGeneratedAssignment: z.string().optional(),
- submissions: z.array(SubmissionSchema),
+ submissions: z.array(z.string()),
  prompt: AssignmentPromptSchema.optional(),
});
```

**SubmissionSchema**
```diff
export const SubmissionSchema = z.object({
  id: z.string(),
+ userId: z.string(),
  assignmentId: z.string(),
  status: SubmissionStatusSchema,
  lastUpdated: z.string().datetime(),
+ repoUrl: z.string().optional(),
  expiredAt: z.string().datetime().nullable(),
});
```

**SubmissionInitSchema**
```diff
export const SubmissionInitSchema = z.object({
+ assignmentId: z.string(),
});
```

**ReviewEntrySchema**
```diff
export const ReviewEntrySchema = z.object({
+ submissionId: z.string(),
  name: z.string(),
  result: ReviewResultSchema,
  score: z.number().max(100).optional(),
  scenario: z.string(),
  path: z.string().optional(),
  lineRange: z.tuple([z.number(), z.number()]).optional(),
  message: z.string(),
});
```
