### PR TITLE
lint(workspace): apply formatting

### DIFF
--- a/apps/client/next.config.mjs
+++ b/apps/client/next.config.mjs
@@ -12,7 +12,7 @@ const baseNextConfig = {
       {
         source: "/github/:api*",
         destination: `${process.env.PRIVATE_GASI_API_URL ?? "http://gasi.request.internal:8080"}/github/:api*`,
-      }
+      },
     ];
   },
   output: "standalone",

--- a/apps/gasi/src/docker.ts
+++ b/apps/gasi/src/docker.ts
@@ -1,5 +1,5 @@
-import { docker } from "./index.js";
 import { TRPCError } from "@trpc/server";
+import { docker } from "./index.js";
 
 const ECR_REPOSITORY_URL = process.env.ECR_REPOSITORY_URL;
 const GITHUB_TOKEN = process.env.GITHUB_TOKEN;

--- a/apps/gasi/src/docker.ts
+++ b/apps/gasi/src/docker.ts
@@ -1,5 +1,5 @@
-import {docker} from "./index.js";
-import {TRPCError} from "@trpc/server";
+import { docker } from "./index.js";
+import { TRPCError } from "@trpc/server";
 
 const ECR_REPOSITORY_URL = process.env.ECR_REPOSITORY_URL;
 const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
@@ -10,7 +10,11 @@ const ASSIGNMENT_BUCKET_ID = process.env.ASSIGNMENT_BUCKET_ID;
 const SUBMISSION_BUCKET_ID = process.env.SUBMISSION_BUCKET_ID;
 
 export function makeRepository(userName: string, assignmentId: string, submissionId: string) {
-  if(!docker) throw new TRPCError({ code: "SERVICE_UNAVAILABLE", message: "이 서버에서는 github 작업을 지원하지 않습니다." });
+  if (!docker)
+    throw new TRPCError({
+      code: "SERVICE_UNAVAILABLE",
+      message: "이 서버에서는 github 작업을 지원하지 않습니다.",
+    });
   const imageName = `${ECR_REPOSITORY_URL}:make-repo`;
   docker.createContainer({
     Tty: true,
@@ -27,11 +31,15 @@ export function makeRepository(userName: string, assignmentId: string, submissio
     ],
     HostConfig: {
       NetworkMode: "host",
-    }
-  })
+    },
+  });
 }
 export function submitRepository(submissionId: string) {
-  if(!docker) throw new TRPCError({ code: "SERVICE_UNAVAILABLE", message: "이 서버에서는 github 작업을 지원하지 않습니다." });
+  if (!docker)
+    throw new TRPCError({
+      code: "SERVICE_UNAVAILABLE",
+      message: "이 서버에서는 github 작업을 지원하지 않습니다.",
+    });
   const imageName = `${ECR_REPOSITORY_URL}:submit-repo`;
   docker.createContainer({
     Tty: true,
@@ -45,6 +53,6 @@ export function submitRepository(submissionId: string) {
     ],
     HostConfig: {
       NetworkMode: "host",
-    }
-  })
+    },
+  });
 }

--- a/apps/gasi/src/index.ts
+++ b/apps/gasi/src/index.ts
@@ -32,7 +32,7 @@ if (process.env.CHANNEL === "local") {
 
 server.post("/github/webhook", async (req, res) => {
   const json = req.body as { payload: string };
-  console.log(json.payload);
+  console.log(JSON.parse(json.payload));
 });
 
 const start = async () => {

--- a/apps/gasi/src/index.ts
+++ b/apps/gasi/src/index.ts
@@ -30,13 +30,14 @@ if (process.env.CHANNEL === "local") {
   });
 }
 
-server.post("/github/webhook", async (_, res) => {
-  server.log.info(res);
+server.post("/github/webhook", async (req, res) => {
+  const json = req.body as { ref: string };
+  console.log(json.ref);
 });
 
 const start = async () => {
   try {
-    await server.listen({ host: '0.0.0.0', port: 8080 });
+    await server.listen({ host: "0.0.0.0", port: 8080 });
     console.log("Server is running on port 8080");
   } catch (err) {
     server.log.error(err);
@@ -44,9 +45,11 @@ const start = async () => {
   }
 };
 
-export const docker = process.env.DOCKER_SOCK ? new Docker({socketPath: process.env.DOCKER_SOCK}) : null;
+export const docker = process.env.DOCKER_SOCK
+  ? new Docker({ socketPath: process.env.DOCKER_SOCK })
+  : null;
 
-if(docker) {
+if (docker) {
   console.log("Dockerode Initiated.");
 }
 start();

--- a/apps/gasi/src/index.ts
+++ b/apps/gasi/src/index.ts
@@ -1,12 +1,12 @@
 import dotenvx from "@dotenvx/dotenvx";
 import fastifyCors from "@fastify/cors";
 import { fastifyTRPCPlugin } from "@trpc/server/adapters/fastify";
+import Docker from "dockerode";
 import Fastify from "fastify";
 import mongoose from "mongoose";
 import { renderTrpcPanel } from "trpc-ui";
 import { createContext } from "./context.js";
 import { appRouter } from "./router.js";
-import Docker from "dockerode";
 
 dotenvx.config();
 
@@ -31,8 +31,8 @@ if (process.env.CHANNEL === "local") {
 }
 
 server.post("/github/webhook", async (req, res) => {
-  const json = req.body as { ref: string };
-  console.log(json.ref);
+  const json = req.body as { payload: string };
+  console.log(json.payload);
 });
 
 const start = async () => {

--- a/apps/gasi/src/routes/submission.ts
+++ b/apps/gasi/src/routes/submission.ts
@@ -17,7 +17,7 @@ import { z } from "zod";
 import { checkRegistered } from "../auth/token.js";
 import { mReview, mReviewEntry, mSubmission } from "../model/index.js";
 import { p } from "../trpc.js";
-import {makeRepository} from "../docker.js";
+import { makeRepository } from "../docker.js";
 
 export const init = p
   .input(SubmissionInitSchema)
@@ -36,8 +36,8 @@ export const init = p
     if (!user.email)
       throw new TRPCError({
         code: "FORBIDDEN",
-        message: "GitHub 계정이 연결되지 않았습니다."
-      })
+        message: "GitHub 계정이 연결되지 않았습니다.",
+      });
     const newDoc = new mSubmission();
     const submissionId = humanId({ separator: "-", capitalize: false });
     newDoc.id = submissionId;

--- a/apps/gasi/src/routes/submission.ts
+++ b/apps/gasi/src/routes/submission.ts
@@ -15,9 +15,9 @@ import { TRPCError } from "@trpc/server";
 import { humanId } from "human-id";
 import { z } from "zod";
 import { checkRegistered } from "../auth/token.js";
+import { makeRepository } from "../docker.js";
 import { mReview, mReviewEntry, mSubmission } from "../model/index.js";
 import { p } from "../trpc.js";
-import { makeRepository } from "../docker.js";
 
 export const init = p
   .input(SubmissionInitSchema)


### PR DESCRIPTION
<!-- PR 제목 한 번 확인해주세요!
브랜치 이름 + 주된 작업 요약
ex. feat/#1 프로젝트 세팅 -->

### **요약 (Summary)**

<!-- 가장 먼저 테크 스펙을 세 줄 내외로 정리합니다. 테크 스펙의 제안 전체에 대해 누가/무엇을/언제/어디서/왜를 간략하면서도 명확하게 적습니다.

> Bottom Navigation 영역(하단 탭)을 유저가 원하는 순서로 커스텀할 수 있게 합니다. 서버에 순서 정렬 및 저장 API를 요청할 수 없으므로, 순서를 로컬에 저장하고 불러옵니다. -->

### **배경 (Background)**

<!-- 프로젝트의 Context를 적습니다. 왜 이 기능을 만드는지, 동기는 무엇인지, 어떤 사용자 문제를 해결하려 하는지, 이전에 이런 시도가 있었는지, 있었다면 해결이 되었는지 등을 포함합니다.

> 다양한 탭을 사용하는 유저는 Segment에 따라 하단 탭의 노출 수와 사용 빈도가 다릅니다. 예를 들어, 20대와 30대의 추천 탭 노출 수 사이는 월 n만 정도입니다. 이러한 유저의 Segment에 맞춰 하단 탭 순서를 유저가 직접 커스텀할 수 있다면 뱅크샐러드가 개인화되었다고 인지할 수 있을 것입니다. -->

### **목표 (Goals)**

<!-- 예상 결과들을 Bullet Point 형태로 나열합니다. 이 목표들과 측정 가능한 임팩트들을 이용해 추후 이 프로젝트의 성공 여부를 평가합니다.

> Bottom Navigation의 순서를 유저가 편집할 수 있게 한다.앱을 껐다 켰을 시에도 유저가 편집한 순서대로 하단 탭을 보이게 한다. -->

### **이외 고려 사항들 (Other Considerations)**

<!-- 고려했었으나 하지 않기로 결정된 사항들을 적습니다. 이렇게 함으로써 이전에 논의되었던 주제가 다시 나오지 않도록 할 수 있고, 이미 논의되었던 내용이더라도 리뷰어들이 다시 살펴볼 수 있습니다.

> 앱 데이터 초기화 시에는 사용자가 커스텀했던 리스트를 모두 날리기로 했었으나, 기존 로직에서 앱 데이터 초기화 시에 로컬 관련 추가 핸들링이 없어 이 기능에서도 앱 데이터 초기화 때에 리스트를 날리는 등 추가적인 기능 구현을 하지 않기로 함. -->
