### PR TITLE
fix(gasi): github 레포지토리 생성

### DIFF
--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -117,6 +117,11 @@ jobs:
           touch scripts/deploy.sh
           echo "aws ecr get-login-password --region ap-northeast-2 | docker login --username AWS --password-stdin ${{ fromJson(env.ECR_OUTPUTS).repository_url.value }}" >> scripts/deploy.sh
           echo "docker image prune -a -f" >> scripts/deploy.sh
+          echo "docker image pull ${{ fromJson(env.ECR_OUTPUTS).repository_url.value }}:make-repo" >> scripts/deploy.sh
+          echo "docker image pull ${{ fromJson(env.ECR_OUTPUTS).repository_url.value }}:submit-repo" >> scripts/deploy.sh
+          echo "docker image tag ${{ fromJson(env.ECR_OUTPUTS).repository_url.value }}:make-repo make-repo:latest" >> scripts/deploy.sh
+          echo "docker image tag ${{ fromJson(env.ECR_OUTPUTS).repository_url.value }}:submit-repo submit-repo:latest" >> scripts/deploy.sh
+          echo "cd /var/deployment && docker-compose down" >> scripts/deploy.sh
           echo "docker-compose -f /var/deployment/docker-compose.yml up -d" >> scripts/deploy.sh
           echo "cd /var/deployment && docker-compose restart nginx" >> scripts/deploy.sh
           zip -r ${{ github.sha }}.zip .

--- a/apps/gasi/src/docker.ts
+++ b/apps/gasi/src/docker.ts
@@ -35,6 +35,7 @@ export async function makeRepository(userName: string, assignmentId: string, sub
       NetworkMode: "gasi",
     },
   });
+  await container.start();
   server.log.info(`Docker container spawned: ${container.id}`);
 }
 export async function submitRepository(submissionId: string) {
@@ -58,5 +59,6 @@ export async function submitRepository(submissionId: string) {
       NetworkMode: "gasi",
     },
   });
+  await container.start();
   server.log.info(`Docker container spawned: ${container.id}`);
 }

--- a/apps/gasi/src/docker.ts
+++ b/apps/gasi/src/docker.ts
@@ -15,7 +15,7 @@ export function makeRepository(userName: string, assignmentId: string, submissio
       code: "SERVICE_UNAVAILABLE",
       message: "이 서버에서는 github 작업을 지원하지 않습니다.",
     });
-  const imageName = `${ECR_REPOSITORY_URL}:make-repo`;
+  const imageName = "make-repo:latest";
   docker.createContainer({
     Tty: true,
     Image: imageName,
@@ -40,7 +40,7 @@ export function submitRepository(submissionId: string) {
       code: "SERVICE_UNAVAILABLE",
       message: "이 서버에서는 github 작업을 지원하지 않습니다.",
     });
-  const imageName = `${ECR_REPOSITORY_URL}:submit-repo`;
+  const imageName = "submit-repo:latest";
   docker.createContainer({
     Tty: true,
     Image: imageName,

--- a/apps/gasi/src/docker.ts
+++ b/apps/gasi/src/docker.ts
@@ -1,5 +1,5 @@
 import { TRPCError } from "@trpc/server";
-import { docker } from "./index.js";
+import { docker, server } from "./index.js";
 
 const ECR_REPOSITORY_URL = process.env.ECR_REPOSITORY_URL;
 const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
@@ -9,39 +9,42 @@ const REQUEST_ENDPOINT = process.env.REQUEST_ENDPOINT;
 const ASSIGNMENT_BUCKET_ID = process.env.ASSIGNMENT_BUCKET_ID;
 const SUBMISSION_BUCKET_ID = process.env.SUBMISSION_BUCKET_ID;
 
-export function makeRepository(userName: string, assignmentId: string, submissionId: string) {
+export async function makeRepository(userName: string, assignmentId: string, submissionId: string) {
   if (!docker || !GITHUB_TOKEN || !ECR_REPOSITORY_URL)
     throw new TRPCError({
       code: "SERVICE_UNAVAILABLE",
       message: "이 서버에서는 github 작업을 지원하지 않습니다.",
     });
   const imageName = "make-repo:latest";
-  docker.createContainer({
+  const env = [
+    `GITHUB_TOKEN=${GITHUB_TOKEN}`,
+    `AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}`,
+    `AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}`,
+    `REQUEST_ENDPOINT=${REQUEST_ENDPOINT}`,
+    `BUCKET_ID=${ASSIGNMENT_BUCKET_ID}`,
+    `USER_LOGIN=${userName}`,
+    `ASSIGNMENT_ID=${assignmentId}`,
+    `SUBMISSION_ID=${submissionId}`,
+  ];
+  server.log.info(env);
+  const container = await docker.createContainer({
     Tty: true,
     Image: imageName,
-    Env: [
-      `GITHUB_TOKEN=${GITHUB_TOKEN}`,
-      `AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}`,
-      `AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}`,
-      `REQUEST_ENDPOINT=${REQUEST_ENDPOINT}`,
-      `BUCKET_ID=${ASSIGNMENT_BUCKET_ID}`,
-      `USER_LOGIN=${userName}`,
-      `ASSIGNMENT_ID=${assignmentId}`,
-      `SUBMISSION_ID=${submissionId}`,
-    ],
+    Env: env,
     HostConfig: {
       NetworkMode: "gasi",
     },
   });
+  server.log.info(`Docker container spawned: ${container.id}`);
 }
-export function submitRepository(submissionId: string) {
+export async function submitRepository(submissionId: string) {
   if (!docker)
     throw new TRPCError({
       code: "SERVICE_UNAVAILABLE",
       message: "이 서버에서는 github 작업을 지원하지 않습니다.",
     });
   const imageName = "submit-repo:latest";
-  docker.createContainer({
+  const container = await docker.createContainer({
     Tty: true,
     Image: imageName,
     Env: [
@@ -55,4 +58,5 @@ export function submitRepository(submissionId: string) {
       NetworkMode: "gasi",
     },
   });
+  server.log.info(`Docker container spawned: ${container.id}`);
 }

--- a/apps/gasi/src/index.ts
+++ b/apps/gasi/src/index.ts
@@ -34,8 +34,7 @@ if (process.env.CHANNEL === "local") {
 }
 
 server.post("/github/webhook", async (req, res) => {
-  const body = req.body as { payload: string };
-  const json = JSON.parse(body.payload);
+  const json = req.body as { ref: string; repository: { name: string } };
   if (!json.ref.endsWith("/submit")) {
     res.send();
     return;

--- a/apps/gasi/src/index.ts
+++ b/apps/gasi/src/index.ts
@@ -53,6 +53,7 @@ server.post("/submission/update", async (req, res) => {
     return;
   }
   doc.status = status;
+  if (status === "STARTED") doc.repoUrl = `https://github.com/ReQuest-members/${id}`;
   await doc.save();
   if (status === "SUBMITTED") {
     // TODO: Send request to CARI


### PR DESCRIPTION
<!-- PR 제목 한 번 확인해주세요!
브랜치 이름 + 주된 작업 요약
ex. feat/#1 프로젝트 세팅 -->

### **요약 (Summary)**

<!-- 가장 먼저 테크 스펙을 세 줄 내외로 정리합니다. 테크 스펙의 제안 전체에 대해 누가/무엇을/언제/어디서/왜를 간략하면서도 명확하게 적습니다.

> Bottom Navigation 영역(하단 탭)을 유저가 원하는 순서로 커스텀할 수 있게 합니다. 서버에 순서 정렬 및 저장 API를 요청할 수 없으므로, 순서를 로컬에 저장하고 불러옵니다. -->

### **배경 (Background)**

<!-- 프로젝트의 Context를 적습니다. 왜 이 기능을 만드는지, 동기는 무엇인지, 어떤 사용자 문제를 해결하려 하는지, 이전에 이런 시도가 있었는지, 있었다면 해결이 되었는지 등을 포함합니다.

> 다양한 탭을 사용하는 유저는 Segment에 따라 하단 탭의 노출 수와 사용 빈도가 다릅니다. 예를 들어, 20대와 30대의 추천 탭 노출 수 사이는 월 n만 정도입니다. 이러한 유저의 Segment에 맞춰 하단 탭 순서를 유저가 직접 커스텀할 수 있다면 뱅크샐러드가 개인화되었다고 인지할 수 있을 것입니다. -->

### **목표 (Goals)**

<!-- 예상 결과들을 Bullet Point 형태로 나열합니다. 이 목표들과 측정 가능한 임팩트들을 이용해 추후 이 프로젝트의 성공 여부를 평가합니다.

> Bottom Navigation의 순서를 유저가 편집할 수 있게 한다.앱을 껐다 켰을 시에도 유저가 편집한 순서대로 하단 탭을 보이게 한다. -->

### **이외 고려 사항들 (Other Considerations)**

<!-- 고려했었으나 하지 않기로 결정된 사항들을 적습니다. 이렇게 함으로써 이전에 논의되었던 주제가 다시 나오지 않도록 할 수 있고, 이미 논의되었던 내용이더라도 리뷰어들이 다시 살펴볼 수 있습니다.

> 앱 데이터 초기화 시에는 사용자가 커스텀했던 리스트를 모두 날리기로 했었으나, 기존 로직에서 앱 데이터 초기화 시에 로컬 관련 추가 핸들링이 없어 이 기능에서도 앱 데이터 초기화 때에 리스트를 날리는 등 추가적인 기능 구현을 하지 않기로 함. -->
