### PR TITLE
feat(client): 신규 과제 생성 성공 페이지 및 UI 개선

### DIFF
--- a/apps/client/src/app/test/page.tsx
+++ b/apps/client/src/app/test/page.tsx
@@ -1,0 +1,5 @@
+import OnboardingSuccess from "@/features/onboarding/profile/components/funnels/components/onboarding-success";
+
+export default function Page() {
+  return <OnboardingSuccess />;
+}

--- a/apps/client/src/app/test/page.tsx
+++ b/apps/client/src/app/test/page.tsx
@@ -1,5 +1,7 @@
-import OnboardingSuccess from "@/features/onboarding/profile/components/funnels/components/onboarding-success";
+"use client";
+import CreateSuccess from "@/features/assignment/create/components/funnels/create-success";
+import { trpc } from "@/shared/api/trpc";
 
-export default function Page() {
-  return <OnboardingSuccess />;
-}
+export default trpc.withTRPC(function Page() {
+  return <CreateSuccess />;
+});

--- a/apps/client/src/entities/assignment/ui/card/assignment-card.tsx
+++ b/apps/client/src/entities/assignment/ui/card/assignment-card.tsx
@@ -46,13 +46,15 @@ export default function AssignmentCard({ assignment }: AssignmentCardProps) {
         </CardHeader>
         <CardContent className="px-0 py-4">
           <div className="space-y-2">
-            <Typography as="p" size="sm" weight="medium">
-              {combinePrompt(prompt.fields)} / {combinePrompt(prompt.companies)}
-            </Typography>
-            <Typography as="h3" size="lg" weight="medium" lineClamp="1">
-              {name}
-            </Typography>
-            <Typography as="p" size="base" weight="medium">
+            <div className="space-y-1">
+              <Typography as="p" size="sm" weight="medium">
+                {combinePrompt(prompt.fields)} / {combinePrompt(prompt.companies)}
+              </Typography>
+              <Typography as="h3" size="xl" weight="bold" lineClamp="1">
+                {name}
+              </Typography>
+            </div>
+            <Typography as="p" size="xs" weight="medium">
               {new Date(lastUpdated).toLocaleDateString()}
             </Typography>
           </div>

--- a/apps/client/src/entities/assignment/ui/card/assignment-list.tsx
+++ b/apps/client/src/entities/assignment/ui/card/assignment-list.tsx
@@ -40,7 +40,7 @@ const AssignmentList: React.FC<AssignmentListProps> = ({
   return (
     <section className="w-full py-12">
       <Flex alignItems="center" justifyContent="between" className="w-full mb-16">
-        <Typography as="h2" size="xl" weight="semibold">
+        <Typography as="h2" size="xl" weight="bold">
           {headerTitle}{" "}
           <Typography as="span" size="xl" weight="bold" color="primary">
             ({total})

--- a/apps/client/src/entities/onboarding/schema/onboard-funnel.ts
+++ b/apps/client/src/entities/onboarding/schema/onboard-funnel.ts
@@ -6,7 +6,8 @@ export const OnboardingSchema = z
       .string()
       .min(2, "이름은 최소 2글자 이상이어야 합니다.")
       .max(10, "이름은 최대 10글자 이하이어야 합니다."),
-    github: z.string().email("GitHub 주소는 유효한 이메일 형식이어야 합니다."),
+    // 깃허브 닉네임에 가능한 것으로 검증좀 해줘.
+    github: z.string().min(1, "깃허브 닉네임은 필수 입력 항목입니다."),
     field: z.array(z.string()).min(1, "직군을 최소 1개 이상 입력해야 합니다."),
     tech: z.array(z.string()).min(1, "기술 스택을 최소 1개 이상 입력해야 합니다."),
     company: z.array(z.string()).min(1, "회사를 최소 1개 이상 입력해야 합니다."),

--- a/apps/client/src/features/assignment/create/components/funnels/confirm-userInfo.tsx
+++ b/apps/client/src/features/assignment/create/components/funnels/confirm-userInfo.tsx
@@ -101,7 +101,7 @@ export default function SelectionForm({ onNext }: ConfirmUserInfoProps) {
           </Flex>
         </Card>
 
-        <Flex direction="col" gap="4" className="mt-8">
+        <Flex gap="4" className="mt-8">
           <Button
             className="w-full py-6"
             onClick={() =>
@@ -117,11 +117,11 @@ export default function SelectionForm({ onNext }: ConfirmUserInfoProps) {
             </Typography>
           </Button>
           <Button
-            variant="secondary"
-            className="w-full py-6"
+            variant="outline"
+            className="w-full py-6 border-2 border-primary"
             onClick={() => onNext("InputUserInfo")}
           >
-            <Typography size="base" weight="semibold" color="primary">
+            <Typography size="base" weight="semibold" color="black">
               정보 새로 입력하기
             </Typography>
           </Button>

--- a/apps/client/src/features/assignment/create/components/funnels/confirm-userInfo.tsx
+++ b/apps/client/src/features/assignment/create/components/funnels/confirm-userInfo.tsx
@@ -46,7 +46,7 @@ export default function SelectionForm({ onNext }: ConfirmUserInfoProps) {
         <Card className="p-8">
           <Flex direction="col" gap="8">
             <Flex direction="col" gap="4">
-              <Typography as="h2" size="lg" weight="medium">
+              <Typography as="h2" size="base" weight="medium">
                 1. 희망 직무를 확인해주세요
               </Typography>
               <Flex wrap="wrap" gap="2">
@@ -64,7 +64,7 @@ export default function SelectionForm({ onNext }: ConfirmUserInfoProps) {
             </Flex>
 
             <Flex direction="col" gap="4">
-              <Typography as="h2" size="lg" weight="medium">
+              <Typography as="h2" size="base" weight="medium">
                 2. 관심 기술을 확인해주세요
               </Typography>
               <Flex wrap="wrap" gap="2">
@@ -82,7 +82,7 @@ export default function SelectionForm({ onNext }: ConfirmUserInfoProps) {
             </Flex>
 
             <Flex direction="col" gap="4">
-              <Typography as="h2" size="lg" weight="medium">
+              <Typography as="h2" size="base" weight="medium">
                 3. 관심 기업을 확인해주세요
               </Typography>
               <Flex wrap="wrap" gap="2">

--- a/apps/client/src/features/assignment/create/components/funnels/create-success.tsx
+++ b/apps/client/src/features/assignment/create/components/funnels/create-success.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import SuccessImage from "@/assets/images/create-success.png";
+import { trpc } from "@/shared/api/trpc";
+import { ROUTES } from "@/shared/constant/url";
 import { Badge } from "@/shared/ui/badge";
 import { Button } from "@/shared/ui/button";
 import { Card } from "@/shared/ui/card";
@@ -11,6 +13,24 @@ import Link from "next/link";
 import CreateAssignmentLayout from "./create-assignment-layout";
 
 export default function CreateSuccess() {
+  const { data: user } = trpc.v1.user.me.useQuery();
+  const { data: assignment } = trpc.v1.asgmt.get.useQuery(
+    { id: user?.lastGeneratedAssignment as string },
+    {
+      enabled: !!user?.lastGeneratedAssignment,
+      refetchInterval: 3000,
+    },
+  );
+
+  if (!assignment) {
+    return null;
+  }
+  console.log(assignment);
+
+  const company = assignment.prompt.companies.join(" / ");
+  const tech = assignment.prompt.techs.join(" / ");
+  const field = assignment.prompt.fields.join(" / ");
+
   return (
     <CreateAssignmentLayout>
       <Flex direction="col" alignItems="center" justifyContent="center" className="p-4 bg-white">
@@ -38,20 +58,19 @@ export default function CreateSuccess() {
 
             <div>
               <Typography size="base" color="muted" align="center">
-                관심기업의 [넷마블]과 관심 기술의 [AI]을 접목하여
+                {`관심기업의 [${company}]과 관심 기술의 [${tech}]을 접목하여`}
               </Typography>
 
               <Typography size="base" color="muted" align="center">
-                넷마블에서 진행한{" "}
                 <Typography as="span" color="primary" weight="bold">
-                  2022년도 프론트엔드 과제전형을 기반으로 하여 생성
+                  {`[${field}] 직무`}
                 </Typography>{" "}
-                하였습니다.
+                에 대한 과제를 생성하였습니다.
               </Typography>
             </div>
 
             <Flex wrap="wrap" gap="2" className="mt-4" justifyContent="center">
-              {["프론트엔드", "AI서비스", "App", "넷마블"].map((keyword) => (
+              {[...company.split(" / "), ...tech.split(" / ")].map((keyword) => (
                 <Badge key={keyword} variant="outline" className="border-[#862E2A] text-[#862E2A]">
                   {keyword}
                 </Badge>
@@ -60,13 +79,10 @@ export default function CreateSuccess() {
           </Flex>
         </Card>
 
-        <Link href="/" className="w-full">
-          <Button
-            className="w-full text-white py-6 rounded-3xl"
-            onClick={() => window.open("https://github.com", "_blank")}
-          >
+        <Link href={ROUTES.EVALUATOIN} className="w-full">
+          <Button className="w-full text-white py-6 rounded-3xl">
             <Typography as="span" size="sm" weight="extrabold" color="white">
-              Github로 이동하기
+              과제 확인하기
             </Typography>
           </Button>
         </Link>

--- a/apps/client/src/features/home/ui/home-banner.tsx
+++ b/apps/client/src/features/home/ui/home-banner.tsx
@@ -8,16 +8,18 @@ import Link from "next/link";
 export default function HomeBanner() {
   return (
     <Banner backgroundImage={banner.src} className="justify-center">
-      <Flex direction="col" alignItems="center" justifyContent="center" gap="4">
-        <Typography as="h1" size="4xl" weight="extrabold" color="white">
-          완벽한 ReQuest와 함께 기업 과제를 준비해보세요!
-        </Typography>
-        <Typography as="p" size="base" weight="semibold" color="white">
-          AI기반 맞춤형 과제 생성과 객관적인 평가를 통해 내 수행능력을 파악할 수 있어요
-        </Typography>
+      <Flex direction="col" alignItems="center" justifyContent="center" gap="6">
+        <Flex direction="col" alignItems="center" justifyContent="center" gap="2">
+          <Typography as="h1" size="4xl" weight="extrabold" color="white">
+            완벽한 ReQuest와 함께 기업 과제를 준비해보세요!
+          </Typography>
+          <Typography as="p" size="base" weight="semibold" color="white">
+            AI기반 맞춤형 과제 생성과 객관적인 평가를 통해 내 수행능력을 파악할 수 있어요
+          </Typography>
+        </Flex>
         <Link
           href={ROUTES.ASSIGNMENT_CREATE}
-          className="rounded-[40px] bg-white hover:bg-white/90 border-[#D9D9D9] px-6 py-2 transition-colors"
+          className="rounded-[40px] bg-white hover:bg-white/90 border-[#D9D9D9] px-4 py-2 transition-colors"
         >
           <Typography size="xs" weight="semibold" color="black">
             AI 과제 생성하러 가기

--- a/apps/client/src/features/home/ui/popular-assignment/components/carousel-indicator.tsx
+++ b/apps/client/src/features/home/ui/popular-assignment/components/carousel-indicator.tsx
@@ -15,7 +15,7 @@ const CarouselIndicators = ({ total, selectedIndex, onSelect }: CarouselIndicato
         type="button"
         className={cn(
           "w-2 h-2 rounded-full transition-all",
-          index === selectedIndex ? "bg-[#787878]" : "bg-gray-300",
+          index === selectedIndex ? "bg-primary" : "bg-gray-300",
         )}
         onClick={() => onSelect?.(index)}
       />

--- a/apps/client/src/features/home/ui/popular-assignment/components/popular-card.tsx
+++ b/apps/client/src/features/home/ui/popular-assignment/components/popular-card.tsx
@@ -1,8 +1,10 @@
+import { ROUTES } from "@/shared/constant/url";
 import { cn } from "@/shared/lib/utils";
 import { Card } from "@/shared/ui/card";
 import Typography from "@/shared/ui/common/typography/typography";
 import Flex from "@/shared/ui/wrapper/flex/flex";
 import type { Assignment } from "@request/specs";
+import { ArrowRight } from "lucide-react";
 import Link from "next/link";
 
 type PopularCardProps = {
@@ -14,27 +16,32 @@ const PopularCard = ({ assignment, isSelected }: PopularCardProps) => {
   return (
     <Card
       className={cn(
-        "transition-all duration-500 ease-in-out",
+        "transition-all duration-500 ease-in-out border-none",
         isSelected ? "flex-[0_0_60%]" : "flex-[0_0_20%]",
       )}
     >
       <Flex
         direction="col"
         justifyContent="between"
-        className={cn("h-[400px] p-8 relative rounded-lg bg-[#3F457B]")}
+        className={cn("h-[400px] rounded-3xl p-8 relative bg-[#3F457B]")}
       >
-        <div className="space-y-2">
-          <Typography as="h3" size="sm" weight="semibold" color="white">
-            {assignment.name}
+        <div className="space-y-5">
+          <Typography as="h3" size="xs" weight="semibold" color="white">
+            {/* {assignment.name} */}
+            {assignment.prompt.companies.map((company) => company).join(" / ")}
           </Typography>
-          <Typography as="p" size="base" color="white">
-            {assignment.description}
+          <Typography as="p" size="2xl" color="white" whitespace="pre-line">
+            {assignment.prompt.techs.map((tech) => tech).join("\n")}
           </Typography>
         </div>
-        <Link href={`/assignment/${assignment.id}`}>
+        <Link
+          href={`${ROUTES.ASSIGNMENT_BUSINESS}/${assignment.id}`}
+          className="flex gap-1 white items-center"
+        >
           <Typography size="base" weight="semibold" color="white">
             자세히보기
           </Typography>
+          <ArrowRight size={20} color="white" />
         </Link>
       </Flex>
     </Card>

--- a/apps/client/src/features/home/ui/popular-assignment/popular-assignment.tsx
+++ b/apps/client/src/features/home/ui/popular-assignment/popular-assignment.tsx
@@ -21,7 +21,7 @@ const PopularAssignment = () => {
       <div className="relative mt-8">
         <div className="overflow-hidden" ref={emblaRef}>
           <div className="flex gap-8">
-            {assignments.map((assignment, index) => (
+            {assignments.slice(0, 5).map((assignment, index) => (
               <PopularCard
                 key={assignment.id}
                 assignment={assignment}

--- a/apps/client/src/features/onboarding/profile/components/funnels/components/onboarding-success.tsx
+++ b/apps/client/src/features/onboarding/profile/components/funnels/components/onboarding-success.tsx
@@ -32,14 +32,14 @@ export default function OnboardingSuccess(props: OnboardingSuccessProps) {
         className="text-center max-w-[676px]"
       >
         <Flex direction="col" alignItems="center" gap="4">
-          <Image src={logo} alt="ReQuest Logo" width={300} height={100} />
-          <Typography size="4xl" weight="semibold" align="center" whitespace="pre-line">
+          <Image src={logo} alt="ReQuest Logo" width={200} height={100} />
+          <Typography size="2xl" weight="semibold" align="center" whitespace="pre-line">
             {"이제 ReQuest와 함께 \n기업 과제를 완벽하게 준비해보세요!"}
           </Typography>
           <Image
             src={onboarding_success}
             alt="Cartoon character"
-            width={460}
+            width={360}
             height={305}
             className="my-4"
           />

--- a/apps/client/src/features/onboarding/profile/components/funnels/input-field.tsx
+++ b/apps/client/src/features/onboarding/profile/components/funnels/input-field.tsx
@@ -70,13 +70,13 @@ export default function InputField({
   };
 
   return (
-    <OnboardingLayout className="h-auto">
+    <OnboardingLayout>
       <Flex direction="col" gap="4" onKeyDown={handleKeyDown} tabIndex={0}>
-        <div className="w-full max-w-7xl min-w-[400px] px-4 py-8">
-          <Typography as="h2" size="xl" weight="bold">
+        <div className="w-full max-w-7xl min-w-[400px] px-4 py-2">
+          <Typography as="h2" size="lg" weight="bold">
             희망 직무를 선택해주세요
           </Typography>
-          <Typography size="base" weight="normal" className="text-muted-foreground">
+          <Typography size="sm" weight="normal" className="text-muted-foreground">
             최대 3개까지 선택 가능합니다.
           </Typography>
           <CategoryFilter

--- a/apps/client/src/features/onboarding/profile/components/funnels/input-field.tsx
+++ b/apps/client/src/features/onboarding/profile/components/funnels/input-field.tsx
@@ -71,7 +71,7 @@ export default function InputField({
 
   return (
     <OnboardingLayout>
-      <Flex direction="col" gap="4" onKeyDown={handleKeyDown} tabIndex={0}>
+      <Flex direction="col" gap="3" onKeyDown={handleKeyDown} tabIndex={0}>
         <div className="w-full max-w-7xl min-w-[400px] px-4 py-2">
           <Typography as="h2" size="lg" weight="bold">
             희망 직무를 선택해주세요

--- a/apps/client/src/features/onboarding/profile/components/funnels/input-github.tsx
+++ b/apps/client/src/features/onboarding/profile/components/funnels/input-github.tsx
@@ -32,34 +32,36 @@ export default function InputGithub({
 
   return (
     <OnboardingLayout>
-      <Flex direction="col" gap="2">
-        <Typography as="h2" size="xl" weight="bold">
-          GitHub에서 사용하는 이메일 주소를 입력해주세요.
-        </Typography>
-        <Typography size="base" weight="normal" className="mb-2" whitespace="pre-line">
-          {"AI 코드리뷰 및 과제 생성을 위해 \n여러분의 GitHub 이메일이 필요해요!"}
-        </Typography>
-        <Label htmlFor="github-email">Github 이메일</Label>
-        <Input
-          id="github-email"
-          type="text"
-          placeholder="github 이메일을 입력해주세요."
-          value={github}
-          onChange={(e) => setGithub(e.target.value)}
-          className={error ? "border-red-500" : ""}
-          onKeyDown={(e) => {
-            if (e.key === "Enter") handleNext();
-          }}
-        />
-        {error && (
-          <Typography size="sm" weight="normal" className="text-red-500 mt-1">
+      <Flex direction="col" gap="12">
+        <div className="space-y-2">
+          <Typography as="h2" size="lg" weight="bold">
+            GitHub에서 사용하는 이메일 주소를 입력해주세요.
+          </Typography>
+          <Typography size="sm" weight="normal" className="mb-2 h-10" whitespace="pre-line">
+            {"AI 코드리뷰 및 과제 생성을 위해 \n여러분의 GitHub 닉네임이 필요해요!"}
+          </Typography>
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="github-email">Github 닉네임</Label>
+          <Input
+            id="github-email"
+            type="text"
+            placeholder="github 닉네임을 입력해주세요."
+            value={github}
+            onChange={(e) => setGithub(e.target.value)}
+            className={error ? "border-red-500" : ""}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") handleNext();
+            }}
+          />
+          <Typography size="sm" weight="normal" className="text-red-500 mt-1 h-5">
             {error}
           </Typography>
-        )}
+        </div>
+        <Button type="button" className="w-full" onClick={handleNext}>
+          다음으로
+        </Button>
       </Flex>
-      <Button type="button" className="w-full" onClick={handleNext}>
-        다음으로
-      </Button>
     </OnboardingLayout>
   );
 }

--- a/apps/client/src/features/onboarding/profile/components/funnels/input-name.tsx
+++ b/apps/client/src/features/onboarding/profile/components/funnels/input-name.tsx
@@ -32,33 +32,35 @@ export default function InputName({
 
   return (
     <OnboardingLayout>
-      <Flex direction="col" gap="2">
-        <Typography as="h2" size="xl" weight="bold">
-          ReQuest에서는 여러분의 이름이 필요해요!
-        </Typography>
-        <Typography size="base" weight="normal" className="mb-2">
-          서비스 시작 전, 이름을 입력해주세요.
-        </Typography>
-        <Label htmlFor="github-email">이름</Label>
-        <Input
-          type="text"
-          placeholder="이름을 입력해주세요."
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-          onKeyDown={(e) => {
-            if (e.key === "Enter") handleNext();
-          }}
-          className={error ? "border-red-500" : ""}
-        />
-        {error && (
-          <Typography size="sm" weight="normal" className="text-red-500 mt-1">
+      <Flex direction="col" gap="12">
+        <div className="space-y-2">
+          <Typography as="h2" size="lg" weight="bold">
+            ReQuest에서는 여러분의 이름이 필요해요!
+          </Typography>
+          <Typography size="sm" weight="normal" className="mb-2 h-10">
+            서비스 시작 전, 이름을 입력해주세요.
+          </Typography>
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="github-email">이름</Label>
+          <Input
+            type="text"
+            placeholder="이름을 입력해주세요."
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") handleNext();
+            }}
+            className={error ? "border-red-500" : ""}
+          />
+          <Typography size="sm" weight="normal" className="text-red-500 mt-1 h-5">
             {error}
           </Typography>
-        )}
+        </div>
+        <Button type="button" className="w-full" onClick={handleNext}>
+          다음으로
+        </Button>
       </Flex>
-      <Button type="button" className="w-full" onClick={handleNext}>
-        다음으로
-      </Button>
     </OnboardingLayout>
   );
 }

--- a/apps/client/src/features/onboarding/profile/components/funnels/input-tech-and-company.tsx
+++ b/apps/client/src/features/onboarding/profile/components/funnels/input-tech-and-company.tsx
@@ -11,7 +11,7 @@ import { Label } from "@/shared/ui/label";
 import Flex from "@/shared/ui/wrapper/flex/flex";
 import SelectItem from "@/widgets/ui/select-item";
 import { X } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { z } from "zod";
 import OnboardingLayout from "./onboarding-layout";
 
@@ -74,14 +74,25 @@ export default function InputTechAndCompany({
     );
   };
 
+  useEffect(() => {
+    if (tech.length > 0) {
+      setTechError(null);
+    }
+  }, [tech]);
+
+  useEffect(() => {
+    if (company.length > 0) {
+      setCompanyError(null);
+    }
+  }, [company]);
+
   return (
     <OnboardingLayout>
-      <Flex direction="col" gap="3">
-        <Typography as="h2" size="xl" weight="bold">
+      <Flex direction="col" gap="6">
+        <Typography as="h2" size="lg" weight="bold" className="mb-10">
           관심 기술 및 기업을 선택해주세요.
         </Typography>
-
-        <Flex direction="col" gap="2" className="mb-8">
+        <Flex direction="col" gap="2">
           <Label htmlFor="tech">관심 기술을 선택해주세요. (최대 3개)</Label>
           <SelectItem
             placeholder="검색어를 입력하여 관심 기술을 선택해주세요."
@@ -89,24 +100,25 @@ export default function InputTechAndCompany({
             value={tech}
             setValue={setTech}
           />
-          {techError && (
-            <Typography size="sm" weight="normal" className="text-red-500 mt-1">
+          {techError ? (
+            <Typography size="sm" weight="normal" className="text-red-500 h-9">
               {techError}
             </Typography>
+          ) : (
+            <Flex direction="row" gap="2" className="h-9">
+              {tech.map((filter) => (
+                <Button
+                  key={filter}
+                  variant="secondary"
+                  className="my-1 rounded-full whitespace-nowrap"
+                  onClick={() => handleRemoveFilter(setTech, filter)}
+                >
+                  {filter}
+                  <X className="ml-2 h-4 w-4 cursor-pointer" />
+                </Button>
+              ))}
+            </Flex>
           )}
-          <Flex direction="row" gap="2" className="h-9">
-            {tech.map((filter) => (
-              <Button
-                key={filter}
-                variant="secondary"
-                className="my-1 rounded-full whitespace-nowrap"
-                onClick={() => handleRemoveFilter(setTech, filter)}
-              >
-                {filter}
-                <X className="ml-2 h-4 w-4 cursor-pointer" />
-              </Button>
-            ))}
-          </Flex>
         </Flex>
 
         <Flex direction="col" gap="2">
@@ -117,24 +129,25 @@ export default function InputTechAndCompany({
             value={company}
             setValue={setCompany}
           />
-          {companyError && (
-            <Typography size="sm" weight="normal" className="text-red-500 mt-1">
+          {companyError ? (
+            <Typography size="sm" weight="normal" className="text-red-500 h-9">
               {companyError}
             </Typography>
+          ) : (
+            <Flex direction="row" gap="2" className="h-9">
+              {company.map((filter) => (
+                <Button
+                  key={filter}
+                  variant="secondary"
+                  className="rounded-full whitespace-nowrap"
+                  onClick={() => handleRemoveFilter(setCompany, filter)}
+                >
+                  {filter}
+                  <X className="my-1 ml-2 h-4 w-4 cursor-pointer" />
+                </Button>
+              ))}
+            </Flex>
           )}
-          <Flex direction="row" gap="2" className="h-9">
-            {company.map((filter) => (
-              <Button
-                key={filter}
-                variant="secondary"
-                className="rounded-full whitespace-nowrap"
-                onClick={() => handleRemoveFilter(setCompany, filter)}
-              >
-                {filter}
-                <X className="my-1 ml-2 h-4 w-4 cursor-pointer" />
-              </Button>
-            ))}
-          </Flex>
         </Flex>
       </Flex>
       <Button type="button" className="w-full" onClick={handleNext}>

--- a/apps/client/src/features/onboarding/profile/components/funnels/input-tech-and-company.tsx
+++ b/apps/client/src/features/onboarding/profile/components/funnels/input-tech-and-company.tsx
@@ -88,8 +88,8 @@ export default function InputTechAndCompany({
 
   return (
     <OnboardingLayout>
-      <Flex direction="col" gap="6">
-        <Typography as="h2" size="lg" weight="bold" className="mb-10">
+      <Flex direction="col" gap="6" className="mb-3">
+        <Typography as="h2" size="lg" weight="bold" className="mb-1">
           관심 기술 및 기업을 선택해주세요.
         </Typography>
         <Flex direction="col" gap="2">

--- a/apps/client/src/features/onboarding/profile/components/funnels/onboarding-layout.tsx
+++ b/apps/client/src/features/onboarding/profile/components/funnels/onboarding-layout.tsx
@@ -20,12 +20,12 @@ export default function OnboardingLayout({
         className={cn("max-w-[1200px] w-full", className || "h-fit-height")}
         justifyContent="center"
       >
-        <Flex direction="row" className="px-4 py-8" justifyContent="center" wrap="wrap">
+        <Flex direction="row" className="px-4 py-4 gap-52" justifyContent="center" wrap="wrap">
           <Flex
             direction="col"
             justifyContent="center"
             alignItems="center"
-            className="flex-[0_0_40%]"
+            className="flex-[0_0_30%]"
           >
             <Image
               src={InputImage}

--- a/apps/client/src/features/onboarding/ui/onboarding-carousel.tsx
+++ b/apps/client/src/features/onboarding/ui/onboarding-carousel.tsx
@@ -56,7 +56,7 @@ export default function OnboardingCarousel() {
             <Flex>
               {ONBOARDINGS.map((ONBOARDING, index) => (
                 // biome-ignore lint/suspicious/noArrayIndexKey: <explanation>
-                <CarouselItem key={`onboarding-item-${index}`} className="self-end">
+                <CarouselItem key={`onboarding-item-${index}`} className="self-end rounded-3xl">
                   <Flex direction="col" alignItems="center" gap="10">
                     <Typography
                       as="p"

--- a/apps/client/src/shared/ui/button.tsx
+++ b/apps/client/src/shared/ui/button.tsx
@@ -22,9 +22,9 @@ const buttonVariants = cva(
         link: "text-neutral-900 underline-offset-4 hover:underline dark:text-neutral-50",
       },
       size: {
-        default: "h-9 px-4 py-2",
-        sm: "h-8 rounded-md px-3 text-xs",
-        lg: "h-10 rounded-md px-8",
+        default: "h-9 px-4 py-2 rounded-3xl",
+        sm: "h-8 rounded-3xl px-3 text-xs",
+        lg: "h-10 rounded-3xl px-8",
         icon: "h-9 w-9",
       },
     },

--- a/apps/client/src/shared/ui/card.tsx
+++ b/apps/client/src/shared/ui/card.tsx
@@ -6,10 +6,7 @@ const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElemen
   ({ className, ...props }, ref) => (
     <div
       ref={ref}
-      className={cn(
-        "rounded-xl border border-neutral-200 bg-white text-neutral-950 shadow dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-50",
-        className,
-      )}
+      className={cn("rounded-xl border border-neutral-200 bg-white text-neutral-950 ", className)}
       {...props}
     />
   ),
@@ -59,4 +56,4 @@ const CardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDiv
 );
 CardFooter.displayName = "CardFooter";
 
-export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent };
+export { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle };

--- a/apps/client/src/shared/ui/command.tsx
+++ b/apps/client/src/shared/ui/command.tsx
@@ -14,7 +14,7 @@ const Command = React.forwardRef<
   <CommandPrimitive
     ref={ref}
     className={cn(
-      "flex h-full w-full flex-col overflow-hidden rounded-md bg-white text-neutral-950 dark:bg-neutral-950 dark:text-neutral-50",
+      "flex h-full w-full flex-col overflow-hidden rounded-sm, bg-white text-neutral-950 dark:bg-neutral-950 dark:text-neutral-50",
       className,
     )}
     {...props}
@@ -43,7 +43,7 @@ const CommandInput = React.forwardRef<
     <CommandPrimitive.Input
       ref={ref}
       className={cn(
-        "flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-none placeholder:text-neutral-500 disabled:cursor-not-allowed disabled:opacity-50 dark:placeholder:text-neutral-400",
+        "flex h-10 w-full rounded-sm bg-transparent py-3 text-sm outline-none placeholder:text-neutral-500 disabled:cursor-not-allowed disabled:opacity-50 dark:placeholder:text-neutral-400",
         className,
       )}
       {...props}

--- a/apps/client/src/shared/ui/menubar.tsx
+++ b/apps/client/src/shared/ui/menubar.tsx
@@ -38,7 +38,7 @@ const MenubarTrigger = React.forwardRef<
   <MenubarPrimitive.Trigger
     ref={ref}
     className={cn(
-      "flex cursor-default select-none items-center rounded-sm px-3 py-1 text-sm font-medium outline-none focus:bg-neutral-100 focus:text-neutral-900 data-[state=open]:bg-neutral-100 data-[state=open]:text-neutral-900 dark:focus:bg-neutral-800 dark:focus:text-neutral-50 dark:data-[state=open]:bg-neutral-800 dark:data-[state=open]:text-neutral-50",
+      "flex cursor-default select-none items-center rounded-sm px-1 py-1 text-sm font-medium outline-none focus:bg-neutral-100 focus:text-neutral-900 data-[state=open]:bg-neutral-100 data-[state=open]:text-neutral-900 dark:focus:bg-neutral-800 dark:focus:text-neutral-50 dark:data-[state=open]:bg-neutral-800 dark:data-[state=open]:text-neutral-50",
       className,
     )}
     {...props}
@@ -206,19 +206,19 @@ MenubarShortcut.displayname = "MenubarShortcut";
 
 export {
   Menubar,
-  MenubarMenu,
-  MenubarTrigger,
-  MenubarContent,
-  MenubarItem,
-  MenubarSeparator,
-  MenubarLabel,
   MenubarCheckboxItem,
+  MenubarContent,
+  MenubarGroup,
+  MenubarItem,
+  MenubarLabel,
+  MenubarMenu,
+  MenubarPortal,
   MenubarRadioGroup,
   MenubarRadioItem,
-  MenubarPortal,
+  MenubarSeparator,
+  MenubarShortcut,
+  MenubarSub,
   MenubarSubContent,
   MenubarSubTrigger,
-  MenubarGroup,
-  MenubarSub,
-  MenubarShortcut,
+  MenubarTrigger,
 };

--- a/apps/client/src/widgets/layout/footer/footer.tsx
+++ b/apps/client/src/widgets/layout/footer/footer.tsx
@@ -1,53 +1,70 @@
 import logo from "@/assets/icons/logo.svg";
+import Typography from "@/shared/ui/common/typography/typography";
+import Flex from "@/shared/ui/wrapper/flex/flex";
 import Image from "next/image";
 import Link from "next/link";
+import { Fragment } from "react";
 
 export default function Footer() {
+  const menus = [
+    {
+      title: "ReQuest 소개",
+      link: "/about",
+    },
+    {
+      title: "멤버십 소개",
+      link: "/membership",
+    },
+    {
+      title: "사용자 이용 약관",
+      link: "/terms",
+    },
+    {
+      title: "개인정보 처리 방침",
+      link: "/privacy",
+    },
+    {
+      title: "자주 묻는 질문/QA",
+      link: "/faq",
+    },
+    {
+      title: "문의하기",
+      link: "/contact",
+    },
+  ];
   return (
-    <footer className="w-full flex justify-center bg-[#F6F6F6] p-8">
-      <div className="container flex h-16 items-center gap-20">
+    <Flex as="footer" className="w-full justify-center bg-[#F6F6F6] p-8">
+      <Flex className="max-w-[1375px] w-full h-16 gap-16 justify-start">
         <Link href="/" className="flex items-center gap-2">
-          <Image src={logo} alt="R_Quest Logo" width={120} height={40} />
+          <Image src={logo} alt="R_Quest Logo" width={117} height={36} />
         </Link>
-        <nav className="md:flex gap-8">
-          <Link
-            href="/about"
-            className="text-[#767676] text-xl font-medium hover:text-primary transition-colors"
-          >
-            ReQuest 소개
-          </Link>
-          <Link
-            href="/membership"
-            className="text-[#767676] text-xl font-medium hover:text-primary transition-colors"
-          >
-            멤버십 소개
-          </Link>
-          <Link
-            href="/terms"
-            className="text-[#767676] text-xl font-medium hover:text-primary transition-colors"
-          >
-            사용자 이용 약관
-          </Link>
-          <Link
-            href="/privacy"
-            className="text-[#767676] text-xl font-medium hover:text-primary transition-colors"
-          >
-            개인정보 처리 방침
-          </Link>
-          <Link
-            href="/faq"
-            className="text-[#767676] text-xl font-medium hover:text-primary transition-colors"
-          >
-            자주 묻는 질문/QA
-          </Link>
-          <Link
-            href="/contact"
-            className="text-[#767676] text-xl font-medium hover:text-primary transition-colors"
-          >
-            문의하기
-          </Link>
-        </nav>
-      </div>
-    </footer>
+        <Flex alignItems="center" gap="4">
+          {menus.map((menu, index) => (
+            <Fragment
+              key={`${menu}-${
+                // biome-ignore lint/suspicious/noArrayIndexKey: <explanation>
+                index
+              }`}
+            >
+              <Link href={menu.link}>
+                <Typography
+                  as="p"
+                  size="sm"
+                  weight="medium"
+                  className="text-[#858899] hover:text-primary"
+                >
+                  {menu.title}
+                </Typography>
+              </Link>
+              {index === menus.length - 1 ? null : (
+                <Typography as="p" size="sm" weight="medium" className="text-[#858899]">
+                  /
+                </Typography>
+              )}
+            </Fragment>
+          ))}
+        </Flex>
+      </Flex>
+    </Flex>
   );
 }

--- a/apps/client/src/widgets/layout/header/default-header.tsx
+++ b/apps/client/src/widgets/layout/header/default-header.tsx
@@ -6,7 +6,7 @@ import Header from "./header";
 
 const DefaultHeader = () => {
   const user = useUserStore((state) => state.user);
-  const isLogin = user?.name || false;
+  const isLogin = user?.name || true;
 
   return (
     <Header>

--- a/apps/client/src/widgets/layout/header/header.tsx
+++ b/apps/client/src/widgets/layout/header/header.tsx
@@ -65,7 +65,7 @@ function Nav(): JSX.Element {
           key={item.href}
           href={item.href}
           className={cn(
-            "text-base font-bold transition-colors hover:text-primary",
+            "text-sm font-bold transition-colors hover:text-primary",
             item.href === activeHref && "text-primary",
           )}
         >
@@ -198,7 +198,7 @@ function MyPageMenu({ name, email }: MyPageMenuProps): JSX.Element {
     <Menubar className="border-none shadow-none">
       <MenubarMenu>
         <MenubarTrigger className="cursor-pointer">
-          <Image src={mypage} alt="마이페이지" width={44} height={44} />
+          <Image src={mypage} alt="마이페이지" width={36} height={36} />
         </MenubarTrigger>
         <MenubarContent className="w-[320px] p-0" align="end">
           <div className="border-b p-4">

--- a/apps/client/src/widgets/layout/header/notification-icon.tsx
+++ b/apps/client/src/widgets/layout/header/notification-icon.tsx
@@ -10,7 +10,7 @@ export default function NotificationIcon({
 
   return (
     <div className="relative inline-flex">
-      <Image src={notification} alt="Notification" width={24} height={24} className="h-6 w-6" />
+      <Image src={notification} alt="Notification" width={26} height={26} className="w-7 h-7" />
       {count > 0 && (
         <div className="absolute -right-2 -top-1 flex h-4 min-w-4 items-center justify-center rounded-full bg-red-500 px-1 text-xs text-white">
           {displayCount}


### PR DESCRIPTION
<!-- PR 제목 한 번 확인해주세요!
브랜치 이름 + 주된 작업 요약
ex. feat/#1 프로젝트 세팅 -->

### **요약 (Summary)**

<!-- 가장 먼저 테크 스펙을 세 줄 내외로 정리합니다. 테크 스펙의 제안 전체에 대해 누가/무엇을/언제/어디서/왜를 간략하면서도 명확하게 적습니다.

> Bottom Navigation 영역(하단 탭)을 유저가 원하는 순서로 커스텀할 수 있게 합니다. 서버에 순서 정렬 및 저장 API를 요청할 수 없으므로, 순서를 로컬에 저장하고 불러옵니다. -->

과제 생성 플로우 레이아웃을 수정하고, 성공 페이지 API를 연결했습니다.

### **배경 (Background)**

<!-- 프로젝트의 Context를 적습니다. 왜 이 기능을 만드는지, 동기는 무엇인지, 어떤 사용자 문제를 해결하려 하는지, 이전에 이런 시도가 있었는지, 있었다면 해결이 되었는지 등을 포함합니다.

> 다양한 탭을 사용하는 유저는 Segment에 따라 하단 탭의 노출 수와 사용 빈도가 다릅니다. 예를 들어, 20대와 30대의 추천 탭 노출 수 사이는 월 n만 정도입니다. 이러한 유저의 Segment에 맞춰 하단 탭 순서를 유저가 직접 커스텀할 수 있다면 뱅크샐러드가 개인화되었다고 인지할 수 있을 것입니다. -->

### **목표 (Goals)**

<!-- 예상 결과들을 Bullet Point 형태로 나열합니다. 이 목표들과 측정 가능한 임팩트들을 이용해 추후 이 프로젝트의 성공 여부를 평가합니다.

> Bottom Navigation의 순서를 유저가 편집할 수 있게 한다.앱을 껐다 켰을 시에도 유저가 편집한 순서대로 하단 탭을 보이게 한다. -->

### **이외 고려 사항들 (Other Considerations)**

<!-- 고려했었으나 하지 않기로 결정된 사항들을 적습니다. 이렇게 함으로써 이전에 논의되었던 주제가 다시 나오지 않도록 할 수 있고, 이미 논의되었던 내용이더라도 리뷰어들이 다시 살펴볼 수 있습니다.

> 앱 데이터 초기화 시에는 사용자가 커스텀했던 리스트를 모두 날리기로 했었으나, 기존 로직에서 앱 데이터 초기화 시에 로컬 관련 추가 핸들링이 없어 이 기능에서도 앱 데이터 초기화 때에 리스트를 날리는 등 추가적인 기능 구현을 하지 않기로 함. -->
