### PR TITLE
feat(client): 쿠키 삭제 기능 추가 및 UI 텍스트 개선

### DIFF
--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -65,8 +65,6 @@
     "typescript": "^5"
   },
   "msw": {
-    "workerDirectory": [
-      "public"
-    ]
+    "workerDirectory": ["public"]
   }
 }

--- a/apps/client/src/app/test/page.tsx
+++ b/apps/client/src/app/test/page.tsx
@@ -1,7 +1,7 @@
 "use client";
-import CreateSuccess from "@/features/assignment/create/components/funnels/create-success";
+import InputUserInfo from "@/features/assignment/create/components/funnels/input-userinfo";
 import { trpc } from "@/shared/api/trpc";
 
 export default trpc.withTRPC(function Page() {
-  return <CreateSuccess />;
+  return <InputUserInfo onNext={() => {}} />;
 });

--- a/apps/client/src/entities/assignment/create/schema/create-assignment-schema.ts
+++ b/apps/client/src/entities/assignment/create/schema/create-assignment-schema.ts
@@ -4,16 +4,16 @@ export const CreateAssignmentSchema = z
   .object({
     field: z
       .array(z.string())
-      .min(1, "At least one job field must be selected.")
-      .max(3, "You can select up to three job fields."),
+      .min(1, "최소 하나의 직무를 선택해야 합니다.")
+      .max(3, "최대 세 개의 직무만 선택할 수 있습니다."),
     tech: z
       .array(z.string())
-      .min(1, "At least one tech stack must be selected.")
-      .max(3, "You can select up to three tech stacks."),
+      .min(1, "최소 하나의 기술 스택을 선택해야 합니다.")
+      .max(3, "최대 세 개의 기술 스택만 선택할 수 있습니다."),
     company: z
       .array(z.string())
-      .min(1, "At least one interested company must be selected.")
-      .max(3, "You can select up to three interested companies."),
+      .min(1, "최소 하나의 관심 기업을 선택해야 합니다.")
+      .max(3, "최대 세 개의 관심 기업만 선택할 수 있습니다."),
   })
   .partial();
 

--- a/apps/client/src/features/assignment/create/components/funnels/create-success.tsx
+++ b/apps/client/src/features/assignment/create/components/funnels/create-success.tsx
@@ -52,7 +52,7 @@ export default function CreateSuccess() {
 
         <Card className="w-full max-w-2xl p-6 mb-8">
           <Flex direction="col" gap="4">
-            <Typography as="h2" size="lg" weight="semibold" align="center">
+            <Typography as="h2" size="lg" weight="bold" align="center">
               제목 : 게임 내 이벤트 추천 시스템
             </Typography>
 

--- a/apps/client/src/features/assignment/create/components/funnels/creating-assignment.tsx
+++ b/apps/client/src/features/assignment/create/components/funnels/creating-assignment.tsx
@@ -69,7 +69,7 @@ export default function CreatingAssignment({ createProps, onNext }: CreatingAssi
   return (
     <CreateAssignmentLayout>
       <Flex direction="col" alignItems="center" justifyContent="center" className="p-4 bg-white">
-        <Flex direction="col" alignItems="center" gap="2" className="mb-12">
+        <Flex direction="col" alignItems="center" gap="2" className="mb-6">
           <Typography as="h1" size="lg" weight="semibold" align="center">
             현재 아래 키워드를 활용해 과제 생성하고 있어요!
           </Typography>
@@ -78,7 +78,7 @@ export default function CreatingAssignment({ createProps, onNext }: CreatingAssi
           </Typography>
         </Flex>
 
-        <div className="relative mb-16">
+        <div className="relative mb-8">
           <Image src={monitor} alt="creating-assignment" width={609} height={300} />
           <div className="absolute inset-0 flex items-center justify-center">
             {/* biome-ignore lint/style/useSelfClosingElements: <explanation> */}
@@ -88,7 +88,7 @@ export default function CreatingAssignment({ createProps, onNext }: CreatingAssi
 
         <Flex wrap="wrap" gap="6" alignItems="center" justifyContent="center" className="max-w-2xl">
           {entries.map((keyword) => (
-            <Badge key={keyword} className="bg-[#862E2A] py-2 px-5 rounded-3xl">
+            <Badge key={keyword} className="bg-[#862E2A] py-1 px-3 rounded-3xl">
               <Typography as="span" size="sm" weight="semibold" color="white">
                 {keyword}
               </Typography>

--- a/apps/client/src/features/assignment/create/components/funnels/input-userinfo.tsx
+++ b/apps/client/src/features/assignment/create/components/funnels/input-userinfo.tsx
@@ -3,12 +3,15 @@ import {
   CreateAssignmentSchema,
   type InProgress,
 } from "@/entities/assignment/create/schema/create-assignment-schema";
+import { companies } from "@/shared/constant/company";
+import { techStack } from "@/shared/constant/tech";
 import { Button } from "@/shared/ui/button";
 import { Card } from "@/shared/ui/card";
 import Typography from "@/shared/ui/common/typography/typography";
 import Flex from "@/shared/ui/wrapper/flex/flex";
 import CategoryFilter from "@/widgets/ui/category-filter/category-filter";
 import SelectItem from "@/widgets/ui/select-item";
+import { X } from "lucide-react";
 import { useState } from "react";
 import { z } from "zod";
 import CreateAssignmentLayout from "./create-assignment-layout";
@@ -19,14 +22,24 @@ interface ConfirmUserInfoProps {
 
 export default function InputUserInfo({ onNext }: ConfirmUserInfoProps) {
   // 유저 정보 가져와서 fields, tech, company로 보여줌
-  const [fields, setFields] = useState<string[]>(["안드로이드", "프론트엔드", "QA"]);
+  const [fields, setFields] = useState<string[]>([]);
+  const handleFilterFields = (filter: string) => {
+    setFields((prev) => (prev.length < 3 ? [...prev, filter] : prev));
+  };
+  const handleRemoveFields = (filter: string) => {
+    setFields((prev) => prev.filter((f) => f !== filter));
+  };
+
   const [tech, setTech] = useState<string[]>([]);
   const [company, setCompany] = useState<string[]>([]);
 
   const [error, setError] = useState<string | null>(null);
 
+  console.log(fields, tech, company);
+
   // 삭제 버튼 누르면 없애야 함.
   const handleRemoveField = (field: string, type: "fields" | "tech" | "company") => {
+    console.log(field, type);
     if (type === "fields") {
       setFields((prev) => prev.filter((f) => f !== field));
     } else if (type === "tech") {
@@ -48,6 +61,13 @@ export default function InputUserInfo({ onNext }: ConfirmUserInfoProps) {
     }
   };
 
+  const handleRemoveFilter = (
+    setFilter: React.Dispatch<React.SetStateAction<string[]>>,
+    value: string,
+  ) => {
+    setFilter((prev) => prev.filter((item) => item !== value));
+  };
+
   return (
     <CreateAssignmentLayout className="h-auto py-10">
       <Flex direction="col" className="w-full max-w-2xl mx-auto p-4">
@@ -63,56 +83,74 @@ export default function InputUserInfo({ onNext }: ConfirmUserInfoProps) {
               </Typography>
               <Flex wrap="wrap" gap="2">
                 <CategoryFilter
+                  showSelectedFilters={false}
                   selectedFilters={fields}
-                  onFilterToggle={(filter) => fields.length < 3 && setFields([...fields, filter])}
-                  onFilterRemove={(filter) => handleRemoveField(filter, "fields")}
+                  onFilterToggle={handleFilterFields}
+                  onFilterRemove={handleRemoveFields}
+                  expanded={false}
+                  className="h-full"
                 />
               </Flex>
             </Flex>
 
             <Flex direction="col" gap="4">
               <Typography as="h2" size="lg" weight="medium">
-                2. 관심 기술을 선택해주세요
+                2. 관심 기술을 선택해주세요 (최대 3개)
               </Typography>
-              <Flex wrap="wrap" gap="2">
+              <Flex direction="col" gap="2">
                 <SelectItem
-                  items={[
-                    { value: "Rest API", label: "Rest API" },
-                    { value: "Adobe Photoshop", label: "Adobe Photoshop" },
-                    { value: "Axios", label: "Axios" },
-                  ]}
+                  items={techStack}
                   value={tech}
                   setValue={(value) => (value.length <= 3 ? setTech(value) : setTech(tech))}
                 />
+                <Flex direction="row" gap="2" className="h-9">
+                  {tech.map((filter) => (
+                    <Button
+                      key={filter}
+                      variant="secondary"
+                      className="rounded-full whitespace-nowrap"
+                      onClick={() => handleRemoveFilter(setTech, filter)}
+                    >
+                      {filter}
+                      <X className="my-1 ml-2 h-4 w-4 cursor-pointer" />
+                    </Button>
+                  ))}
+                </Flex>
               </Flex>
             </Flex>
 
             <Flex direction="col" gap="4">
               <Typography as="h2" size="lg" weight="medium">
-                3. 관심 기업을 선택해주세요
+                3. 관심 기업을 선택해주세요 (최대 3개)
               </Typography>
-              <Flex wrap="wrap" gap="2">
+              <Flex direction="col" wrap="wrap" gap="2">
                 <SelectItem
-                  items={[
-                    { value: "Kakao", label: "Kakao" },
-                    { value: "Naver", label: "Naver" },
-                    { value: "Google", label: "Google" },
-                  ]}
+                  items={companies}
                   value={company}
                   setValue={(value) =>
                     value.length <= 3 ? setCompany(value) : setCompany(company)
                   }
                 />
+                <Flex direction="row" gap="2" className="h-9">
+                  {company.map((filter) => (
+                    <Button
+                      key={filter}
+                      variant="secondary"
+                      className="rounded-full whitespace-nowrap"
+                      onClick={() => handleRemoveFilter(setCompany, filter)}
+                    >
+                      {filter}
+                      <X className="my-1 ml-2 h-4 w-4 cursor-pointer" />
+                    </Button>
+                  ))}
+                </Flex>
               </Flex>
             </Flex>
           </Flex>
         </Card>
-
-        {error && (
-          <Typography size="sm" weight="normal" className="text-red-500 mt-2">
-            {error}
-          </Typography>
-        )}
+        <Typography size="sm" weight="normal" className="text-red-500 mt-2">
+          {error}
+        </Typography>
 
         <Flex direction="col" gap="4" className="mt-8">
           <Button className="w-full py-6" onClick={handleNext}>

--- a/apps/client/src/features/assignment/ui/assignment-banner.tsx
+++ b/apps/client/src/features/assignment/ui/assignment-banner.tsx
@@ -4,7 +4,7 @@ import Banner from "@/widgets/ui/banner";
 
 export default function AssignmentBanner() {
   return (
-    <Banner backgroundImage={banner.src} className="justify-end py-14 px-24 gap-6">
+    <Banner backgroundImage={banner.src} className="justify-end py-14 px-24 gap-6 h-[350px]">
       <Typography as="p" size="3xl" weight="extrabold" color="white">
         AI과제생성을 통해 기업 과제 연습해보세요!
       </Typography>

--- a/apps/client/src/features/evaluation/ui/ongoing-assignment.tsx
+++ b/apps/client/src/features/evaluation/ui/ongoing-assignment.tsx
@@ -43,7 +43,7 @@ export default function OngoingAssignment(props: OngoingAssignmentProps) {
               {props?.name || "과제 이름"}
             </Typography>
           </div>
-          <Typography size="xs">{new Date(getDate()).toLocaleDateString()}</Typography>
+          <Typography size="sm">{new Date(getDate()).toLocaleDateString()}</Typography>
         </div>
         <Button
           variant="link"

--- a/apps/client/src/pages/assignment-detail-page.tsx
+++ b/apps/client/src/pages/assignment-detail-page.tsx
@@ -84,7 +84,7 @@ const AssignmentDetailPage = () => {
       >
         <div className="space-y-10">
           <Typography as="p" size="3xl" weight="extrabold">
-            과제 설명
+            과제 개요 및 설명
           </Typography>
           <Typography
             as="p"

--- a/apps/client/src/pages/assignment/business-assignment-page.tsx
+++ b/apps/client/src/pages/assignment/business-assignment-page.tsx
@@ -2,6 +2,7 @@
 
 import AssignmentList from "@/entities/assignment/ui/card/assignment-list";
 import { trpc } from "@/shared/api/trpc";
+import Flex from "@/shared/ui/wrapper/flex/flex";
 import CategoryFilter from "@/widgets/ui/category-filter/category-filter";
 import type { Assignment } from "@request/specs";
 import { useState } from "react";
@@ -28,30 +29,33 @@ const BusinessAssignmentPage = () => {
   };
 
   return (
-    <div className="max-w-[1300px] w-full flex flex-col">
-      <div className="space-y-6">
-        <div className="space-y-2 px-24 py-14">
-          <h1 className="text-2xl font-bold">기업과제</h1>
-          <p className="text-muted-foreground">
-            Re_Quest는 개발자들이 기업별 과제 전형을 탐색하고
-            <br className="hidden sm:inline" />
-            실전 과제를 수행하며, 자신만의 해결 능력을 강화할 수 있도록 돕습니다.
-          </p>
-          <CategoryFilter
-            selectedFilters={selectedFilters}
-            onFilterToggle={handleFilterToggle}
-            onFilterRemove={handleFilterRemove}
+    <Flex justifyContent="center">
+      <Flex direction="col" className="max-w-[1300px] w-full">
+        <div className="space-y-6">
+          <div className="space-y-2 px-24 py-12">
+            <h1 className="text-2xl font-bold">기업과제</h1>
+            <p className="text-muted-foreground">
+              Re_Quest는 개발자들이 기업별 과제 전형을 탐색하고
+              <br className="hidden sm:inline" />
+              실전 과제를 수행하며, 자신만의 해결 능력을 강화할 수 있도록 돕습니다.
+            </p>
+            <CategoryFilter
+              className="w-[950px]"
+              selectedFilters={selectedFilters}
+              onFilterToggle={handleFilterToggle}
+              onFilterRemove={handleFilterRemove}
+            />
+          </div>
+        </div>
+        <div className="w-full px-24 mb-24">
+          <AssignmentList
+            assignments={filteredAssignments}
+            headerTitle="기업 과제"
+            extraControls={undefined}
           />
         </div>
-      </div>
-      <div className="w-full px-24 mb-24">
-        <AssignmentList
-          assignments={filteredAssignments}
-          headerTitle="기업 과제"
-          extraControls={undefined}
-        />
-      </div>
-    </div>
+      </Flex>
+    </Flex>
   );
 };
 

--- a/apps/client/src/pages/evaluation/evaluation-page.tsx
+++ b/apps/client/src/pages/evaluation/evaluation-page.tsx
@@ -49,7 +49,7 @@ const EvaluationPage = () => {
               분석하여 개발자가 더 나은 코드를 작성할 수 있도록 돕습니다.`}
             </Typography>
           </section>
-          <section className="space-y-3">
+          <section className="space-y-4">
             <Typography as="p" size="lg" weight="semibold">
               진행중인 과제
             </Typography>

--- a/apps/client/src/shared/lib/cookie.ts
+++ b/apps/client/src/shared/lib/cookie.ts
@@ -7,3 +7,8 @@ export const setCookie = async (key: string, value: string, options?: NextApiReq
   const cookieStore = await cookies();
   cookieStore.set(key, value, options);
 };
+
+export const clearCookie = async () => {
+  const cookieStore = await cookies();
+  cookieStore.delete("accessToken");
+};

--- a/apps/client/src/widgets/layout/header/header.tsx
+++ b/apps/client/src/widgets/layout/header/header.tsx
@@ -4,6 +4,7 @@ import logo from "@/assets/icons/logo.svg";
 import mypage from "@/assets/icons/mypage.svg";
 import pencil from "@/assets/icons/pencil.svg";
 import { ROUTES } from "@/shared/constant/url";
+import { clearCookie } from "@/shared/lib/cookie";
 import { cn } from "@/shared/lib/utils";
 import Typography from "@/shared/ui/common/typography/typography";
 import {
@@ -190,7 +191,7 @@ const MENUBAR_ITEMS = [
   { title: "서비스 기본 설정", onClick: preventEvent },
   { title: "나의 대시보드", onClick: preventEvent },
   { title: "나의 포인트 현황", onClick: preventEvent },
-  { title: "로그아웃", onClick: preventEvent },
+  { title: "로그아웃", onClick: clearCookie },
 ];
 
 function MyPageMenu({ name, email }: MyPageMenuProps): JSX.Element {

--- a/apps/client/src/widgets/ui/banner.tsx
+++ b/apps/client/src/widgets/ui/banner.tsx
@@ -1,3 +1,4 @@
+import { cn } from "@/shared/lib/utils";
 import type { PropsWithChildren, Ref } from "react";
 
 interface BannerProps {
@@ -15,7 +16,7 @@ export default function Banner({
   return (
     <div
       ref={ref}
-      className={`relative h-[456px] w-full bg-cover bg-center flex flex-col ${className}`}
+      className={cn(`relative h-[456px] w-full bg-cover bg-center flex flex-col ${className}`)}
       style={{ backgroundImage: `url(${backgroundImage})` }}
       {...props}
     >

--- a/apps/client/src/widgets/ui/category-filter/category-filter.tsx
+++ b/apps/client/src/widgets/ui/category-filter/category-filter.tsx
@@ -26,7 +26,7 @@ export default function CategoryFilter({
   expanded = true,
 }: CategoryFilterProps) {
   const [isExpanded, setIsExpanded] = useState(false);
-  const initialVisibleCount = expanded ? 10 : allFilters.length;
+  const initialVisibleCount = expanded ? 9 : allFilters.length;
 
   return (
     <Flex direction="col" className={cn("space-y-6 min-w-[400px]")}>
@@ -51,6 +51,7 @@ export default function CategoryFilter({
             "w-full flex gap-2 flex-wrap",
             !isExpanded ? `${className || "h-10"} overflow-y-hidden` : "",
             expanded ? "" : "overflow-none!",
+            className,
           )}
         >
           {allFilters.map((filter, index) => (


### PR DESCRIPTION
<!-- PR 제목 한 번 확인해주세요!
브랜치 이름 + 주된 작업 요약
ex. feat/#1 프로젝트 세팅 -->

### **요약 (Summary)**

<!-- 가장 먼저 테크 스펙을 세 줄 내외로 정리합니다. 테크 스펙의 제안 전체에 대해 누가/무엇을/언제/어디서/왜를 간략하면서도 명확하게 적습니다.

> Bottom Navigation 영역(하단 탭)을 유저가 원하는 순서로 커스텀할 수 있게 합니다. 서버에 순서 정렬 및 저장 API를 요청할 수 없으므로, 순서를 로컬에 저장하고 불러옵니다. -->

### **배경 (Background)**

<!-- 프로젝트의 Context를 적습니다. 왜 이 기능을 만드는지, 동기는 무엇인지, 어떤 사용자 문제를 해결하려 하는지, 이전에 이런 시도가 있었는지, 있었다면 해결이 되었는지 등을 포함합니다.

> 다양한 탭을 사용하는 유저는 Segment에 따라 하단 탭의 노출 수와 사용 빈도가 다릅니다. 예를 들어, 20대와 30대의 추천 탭 노출 수 사이는 월 n만 정도입니다. 이러한 유저의 Segment에 맞춰 하단 탭 순서를 유저가 직접 커스텀할 수 있다면 뱅크샐러드가 개인화되었다고 인지할 수 있을 것입니다. -->

### **목표 (Goals)**

<!-- 예상 결과들을 Bullet Point 형태로 나열합니다. 이 목표들과 측정 가능한 임팩트들을 이용해 추후 이 프로젝트의 성공 여부를 평가합니다.

> Bottom Navigation의 순서를 유저가 편집할 수 있게 한다.앱을 껐다 켰을 시에도 유저가 편집한 순서대로 하단 탭을 보이게 한다. -->

### **이외 고려 사항들 (Other Considerations)**

<!-- 고려했었으나 하지 않기로 결정된 사항들을 적습니다. 이렇게 함으로써 이전에 논의되었던 주제가 다시 나오지 않도록 할 수 있고, 이미 논의되었던 내용이더라도 리뷰어들이 다시 살펴볼 수 있습니다.

> 앱 데이터 초기화 시에는 사용자가 커스텀했던 리스트를 모두 날리기로 했었으나, 기존 로직에서 앱 데이터 초기화 시에 로컬 관련 추가 핸들링이 없어 이 기능에서도 앱 데이터 초기화 때에 리스트를 날리는 등 추가적인 기능 구현을 하지 않기로 함. -->
