### PR TITLE
refactor(client): defualt image, 헤더 로그인 상태 로직 수정

### DIFF
--- a/apps/client/src/features/evaluation/ui/evaluation-item.tsx
+++ b/apps/client/src/features/evaluation/ui/evaluation-item.tsx
@@ -39,7 +39,7 @@ export default function EvaluationItem(props: EvaluationItemProps) {
         <Typography size="xs">{getDate(props.lastUpdated)}</Typography>
       </div>
       <div className="space-y-2">
-        <Typography size="sm">과제 점수: 50</Typography>
+        {/* <Typography size="sm">과제 점수: 50</Typography> */}
         <Button
           variant="link"
           className={`w-[calc(100%)] self-center bg-[#8A1B22] py-6 rounded-lg hover:no-underline text-white font-bold text-sm flex items-center ${isReviewing && "bg-[#C3CCD5] text-black"}`}

--- a/apps/client/src/pages/assignment-detail-page.tsx
+++ b/apps/client/src/pages/assignment-detail-page.tsx
@@ -2,6 +2,7 @@
 
 import lotte from "@/assets/images/lotte.png";
 import { trpc } from "@/shared/api/trpc";
+import { type Company, companyImages } from "@/shared/constant/company";
 import { combinePrompt } from "@/shared/lib/utils";
 import { Button } from "@/shared/ui/button";
 import Typography from "@/shared/ui/common/typography/typography";
@@ -49,7 +50,14 @@ const AssignmentDetailPage = () => {
         className="self-center w-full px-[100px] py-[60px] max-w-screen-2xl"
       >
         <Flex gap="10" className="w-full">
-          <Image src={lotte} alt="기업 이미지" width={360} height={240} />
+          <Image
+            src={
+              companyImages[combinePrompt(data?.prompt?.companies || ["롯데"]) as Company] || lotte
+            }
+            alt="기업 이미지"
+            width={360}
+            height={240}
+          />
           <Flex direction="col" justifyContent="between" className="w-full">
             <Flex direction="col" className="leading-10" gap="3">
               <Typography as="p" size="lg">

--- a/apps/client/src/pages/evaluation/evaluation-page.tsx
+++ b/apps/client/src/pages/evaluation/evaluation-page.tsx
@@ -9,28 +9,30 @@ import Flex from "@/shared/ui/wrapper/flex/flex";
 const EvaluationPage = () => {
   const { data: listData } = trpc.v1.submission.list.useQuery(undefined, { refetchInterval: 3000 });
   const { data: assignmentList } = trpc.v1.asgmt.list.useQuery({});
-  const ongoingAssignments = listData?.filter(
+  const ongoingSubmissions = listData?.filter(
     (submission) => submission.status === "PREPARING" || submission.status === "STARTED",
   )[0];
-  const restAssignments = listData?.filter(
+  const restSubmissions = listData?.filter(
     (submission) => submission.status !== "PREPARING" && submission.status !== "STARTED",
   );
   const { data: assignmentData } = trpc.v1.asgmt.get.useQuery(
-    { id: ongoingAssignments?.assignmentId as string },
-    { enabled: typeof ongoingAssignments !== "undefined" },
+    { id: ongoingSubmissions?.assignmentId as string },
+    { enabled: typeof ongoingSubmissions !== "undefined" },
   );
   const ongoingData = {
-    status: ongoingAssignments?.status,
-    repoUrl: ongoingAssignments?.repoUrl,
+    status: ongoingSubmissions?.status,
+    repoUrl: ongoingSubmissions?.repoUrl,
     prompt: assignmentData?.prompt,
     name: assignmentData?.name,
     lastUpdated: assignmentData?.lastUpdated,
   };
   const filteredRestAssignments = assignmentList?.data.filter((assignment, idx) => {
-    if (restAssignments?.some((rest) => rest.assignmentId === assignment.id)) {
+    const find = restSubmissions?.find((rest) => rest.assignmentId === assignment.id);
+    if (find) {
       return {
         ...assignmentList.data[idx],
         status: assignment.status,
+        submissionId: find.id,
       };
     }
   });
@@ -62,7 +64,7 @@ const EvaluationPage = () => {
         <Typography as="p" size="lg" weight="semibold">
           평가중{" "}
           <Typography as="span" size="lg" weight="bold" color="primary">
-            &#40;{restAssignments?.length || 0}&#41;
+            &#40;{restSubmissions?.length || 0}&#41;
           </Typography>
         </Typography>
         <Flex

--- a/apps/client/src/widgets/layout/header/default-header.tsx
+++ b/apps/client/src/widgets/layout/header/default-header.tsx
@@ -6,7 +6,7 @@ import Header from "./header";
 
 const DefaultHeader = () => {
   const user = useUserStore((state) => state.user);
-  const isLogin = user?.name || true;
+  const isLogin = user?.name || undefined;
 
   return (
     <Header>


### PR DESCRIPTION
<!-- PR 제목 한 번 확인해주세요!
브랜치 이름 + 주된 작업 요약
ex. feat/#1 프로젝트 세팅 -->

### **요약 (Summary)**

<!-- 가장 먼저 테크 스펙을 세 줄 내외로 정리합니다. 테크 스펙의 제안 전체에 대해 누가/무엇을/언제/어디서/왜를 간략하면서도 명확하게 적습니다.

> Bottom Navigation 영역(하단 탭)을 유저가 원하는 순서로 커스텀할 수 있게 합니다. 서버에 순서 정렬 및 저장 API를 요청할 수 없으므로, 순서를 로컬에 저장하고 불러옵니다. -->

### **배경 (Background)**

<!-- 프로젝트의 Context를 적습니다. 왜 이 기능을 만드는지, 동기는 무엇인지, 어떤 사용자 문제를 해결하려 하는지, 이전에 이런 시도가 있었는지, 있었다면 해결이 되었는지 등을 포함합니다.

> 다양한 탭을 사용하는 유저는 Segment에 따라 하단 탭의 노출 수와 사용 빈도가 다릅니다. 예를 들어, 20대와 30대의 추천 탭 노출 수 사이는 월 n만 정도입니다. 이러한 유저의 Segment에 맞춰 하단 탭 순서를 유저가 직접 커스텀할 수 있다면 뱅크샐러드가 개인화되었다고 인지할 수 있을 것입니다. -->

### **목표 (Goals)**

<!-- 예상 결과들을 Bullet Point 형태로 나열합니다. 이 목표들과 측정 가능한 임팩트들을 이용해 추후 이 프로젝트의 성공 여부를 평가합니다.

> Bottom Navigation의 순서를 유저가 편집할 수 있게 한다.앱을 껐다 켰을 시에도 유저가 편집한 순서대로 하단 탭을 보이게 한다. -->

### **이외 고려 사항들 (Other Considerations)**

<!-- 고려했었으나 하지 않기로 결정된 사항들을 적습니다. 이렇게 함으로써 이전에 논의되었던 주제가 다시 나오지 않도록 할 수 있고, 이미 논의되었던 내용이더라도 리뷰어들이 다시 살펴볼 수 있습니다.

> 앱 데이터 초기화 시에는 사용자가 커스텀했던 리스트를 모두 날리기로 했었으나, 기존 로직에서 앱 데이터 초기화 시에 로컬 관련 추가 핸들링이 없어 이 기능에서도 앱 데이터 초기화 때에 리스트를 날리는 등 추가적인 기능 구현을 하지 않기로 함. -->
