### PR TITLE
fix(client): callback 컴포넌트에 Suspense 추가 및 불필요한 console.log 제거

### DIFF
--- a/apps/client/src/app/callback/page.tsx
+++ b/apps/client/src/app/callback/page.tsx
@@ -1,5 +1,10 @@
 import CallbackPage from "@/pages/callback/callback-page";
+import { Suspense } from "react";
 
 export default function Callback() {
-  return <CallbackPage />;
+  return (
+    <Suspense fallback={<div>Loading...</div>}>
+      <CallbackPage />
+    </Suspense>
+  );
 }

--- a/apps/client/src/features/assignment/create/components/funnels/create-success.tsx
+++ b/apps/client/src/features/assignment/create/components/funnels/create-success.tsx
@@ -25,7 +25,7 @@ export default function CreateSuccess() {
   if (!assignment) {
     return null;
   }
-  console.log(assignment);
+  // console.log(assignment);
 
   const company = assignment.prompt.companies.join(" / ");
   const tech = assignment.prompt.techs.join(" / ");

--- a/apps/client/src/features/assignment/create/components/funnels/input-userinfo.tsx
+++ b/apps/client/src/features/assignment/create/components/funnels/input-userinfo.tsx
@@ -35,7 +35,7 @@ export default function InputUserInfo({ onNext }: ConfirmUserInfoProps) {
 
   const [error, setError] = useState<string | null>(null);
 
-  console.log(fields, tech, company);
+  // console.log(fields, tech, company);
 
   // 삭제 버튼 누르면 없애야 함.
   const handleRemoveField = (field: string, type: "fields" | "tech" | "company") => {

--- a/apps/client/src/features/evaluation/ui/evaluation-overall-score.tsx
+++ b/apps/client/src/features/evaluation/ui/evaluation-overall-score.tsx
@@ -34,16 +34,16 @@ const EvaluationOverallScore = () => {
           <span className="text-primary">{Math.floor(overallScore) || 0}점</span> 이에요
         </Typography>
         <Typography as="p" weight="semibold" className="text-[#939393]">
-          {commentByScore(overallScore || 0)}
+          {commentByScore(Math.floor(overallScore) || 0)}
         </Typography>
       </div>
       <div className="bg-[#E4E4E4] w-full text-[#B7B7B7] py-2 px-4 text-right rounded-full relative font-bold">
         100
         <div
           className="bg-primary text-white py-2 px-4 text-right rounded-full absolute top-0 left-0"
-          style={{ width: `${overallScore || 0}%` }}
+          style={{ width: `${Math.floor(overallScore) || 0}%` }}
         >
-          {overallScore || 0}
+          {Math.floor(overallScore) || 0}
         </div>
       </div>
     </>

--- a/apps/client/src/pages/assignment/assignment-page.tsx
+++ b/apps/client/src/pages/assignment/assignment-page.tsx
@@ -1,10 +1,12 @@
 import AssignmentList from "@/entities/assignment/ui/card/assignment-list";
 import AssignmentBanner from "@/features/assignment/ui/assignment-banner";
+import { ROUTES } from "@/shared/constant/url";
 import { cn } from "@/shared/lib/utils";
 import { mockAssignments } from "@/shared/mocks/constant/assignment.mock";
 import { Button } from "@/shared/ui/button";
 import Typography from "@/shared/ui/common/typography/typography";
 import Flex from "@/shared/ui/wrapper/flex/flex";
+import Link from "next/link";
 
 export default function AssignmentPage() {
   return (
@@ -15,19 +17,21 @@ export default function AssignmentPage() {
           headerTitle="생성한 과제"
           assignments={mockAssignments}
           extraControls={
-            <Button
-              className={cn(
-                "bg-[#8B1D1D] hover:bg-[#7A1919] text-white w-full text-lg font-medium",
-                "w-[162px] h-[44px] px-4 box-border",
-              )}
-            >
-              <Typography as="span" size="lg" weight="medium" color="white" className="mr-2">
-                +
-              </Typography>
-              <Typography as="span" size="lg" weight="medium" color="white">
-                과제 생성하기
-              </Typography>
-            </Button>
+            <Link href={ROUTES.ASSIGNMENT_CREATE}>
+              <Button
+                className={cn(
+                  "bg-[#8B1D1D] hover:bg-[#7A1919] text-white w-full text-lg font-medium",
+                  "w-[162px] h-[44px] px-4 box-border",
+                )}
+              >
+                <Typography as="span" size="lg" weight="medium" color="white" className="mr-2">
+                  +
+                </Typography>
+                <Typography as="span" size="lg" weight="medium" color="white">
+                  과제 생성하기
+                </Typography>
+              </Button>
+            </Link>
           }
         />
       </Flex>

--- a/apps/client/src/pages/evaluation/evaluation-page.tsx
+++ b/apps/client/src/pages/evaluation/evaluation-page.tsx
@@ -8,17 +8,22 @@ import Flex from "@/shared/ui/wrapper/flex/flex";
 
 const EvaluationPage = () => {
   const { data: listData } = trpc.v1.submission.list.useQuery(undefined, { refetchInterval: 3000 });
+  // console.log("listdata", listData);
   const { data: assignmentList } = trpc.v1.asgmt.list.useQuery({});
+  // console.log("assignmentList", assignmentList);
   const ongoingSubmissions = listData?.filter(
     (submission) => submission.status === "PREPARING" || submission.status === "STARTED",
   )[0];
+  // console.log("ongoingSubmissions", ongoingSubmissions);
   const restSubmissions = listData?.filter(
     (submission) => submission.status !== "PREPARING" && submission.status !== "STARTED",
   );
+  // console.log("restSubmissions", restSubmissions);
   const { data: assignmentData } = trpc.v1.asgmt.get.useQuery(
     { id: ongoingSubmissions?.assignmentId as string },
     { enabled: typeof ongoingSubmissions !== "undefined" },
   );
+  // console.log("assignmentData", assignmentData);
   const ongoingData = {
     status: ongoingSubmissions?.status,
     repoUrl: ongoingSubmissions?.repoUrl,
@@ -29,7 +34,6 @@ const EvaluationPage = () => {
   const filteredRestAssignments = assignmentList?.data
     .map((assignment, idx) => {
       const find = restSubmissions?.find((rest) => rest.assignmentId === assignment.id);
-      console.log(find);
       if (find) {
         return {
           ...assignmentList.data[idx],
@@ -40,6 +44,8 @@ const EvaluationPage = () => {
       return null;
     })
     .filter((assignment) => assignment !== null);
+
+  // console.log("filteredRestAssignments", filteredRestAssignments);
 
   return (
     <Flex as="main" direction="col" className="w-full px-24 py-14">

--- a/apps/client/src/shared/mocks/browser.ts
+++ b/apps/client/src/shared/mocks/browser.ts
@@ -1,14 +1,14 @@
-import { setupWorker } from "msw/browser";
-import { handlers } from "./handlers";
+// import { setupWorker } from "msw/browser";
+// import { handlers } from "./handlers";
 
-const worker = setupWorker(...handlers);
+// const worker = setupWorker(...handlers);
 
-export const startWorker = async () => {
-  try {
-    await worker.start({
-      onUnhandledRequest: "bypass",
-    });
-  } catch (error) {
-    console.error("[MSW] Failed to start Mock Service Worker:", error);
-  }
-};
+// export const startWorker = async () => {
+//   try {
+//     await worker.start({
+//       onUnhandledRequest: "bypass",
+//     });
+//   } catch (error) {
+//     console.error("[MSW] Failed to start Mock Service Worker:", error);
+//   }
+// };

--- a/apps/client/src/widgets/query-provider.tsx
+++ b/apps/client/src/widgets/query-provider.tsx
@@ -2,32 +2,32 @@
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { ReactNode } from "react";
-import { useEffect, useRef, useState } from "react";
+import { useState } from "react";
 
 const QueryProvider = ({ children }: { children: ReactNode }) => {
   const [queryClient] = useState(() => new QueryClient());
 
-  const [isMocking, setIsMocking] = useState(false);
-  const isWorkerStarted = useRef(false);
+  // const [isMocking, setIsMocking] = useState(false);
+  // const isWorkerStarted = useRef(false);
 
-  useEffect(() => {
-    async function enableApiMocking() {
-      if (typeof window !== "undefined" && !isWorkerStarted.current) {
-        isWorkerStarted.current = true;
+  // useEffect(() => {
+  //   async function enableApiMocking() {
+  //     if (typeof window !== "undefined" && !isWorkerStarted.current) {
+  //       isWorkerStarted.current = true;
 
-        const { startWorker } = await import("@/shared/mocks/browser");
-        await startWorker();
+  //       const { startWorker } = await import("@/shared/mocks/browser");
+  //       await startWorker();
 
-        setIsMocking(true);
-      }
-    }
+  //       setIsMocking(true);
+  //     }
+  //   }
 
-    enableApiMocking();
-  }, []);
+  //   enableApiMocking();
+  // }, []);
 
-  if (!isMocking) {
-    return null;
-  }
+  // if (!isMocking) {
+  //   return null;
+  // }
 
   return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
 };


### PR DESCRIPTION
<!-- PR 제목 한 번 확인해주세요!
브랜치 이름 + 주된 작업 요약
ex. feat/#1 프로젝트 세팅 -->

### **요약 (Summary)**

<!-- 가장 먼저 테크 스펙을 세 줄 내외로 정리합니다. 테크 스펙의 제안 전체에 대해 누가/무엇을/언제/어디서/왜를 간략하면서도 명확하게 적습니다.

> Bottom Navigation 영역(하단 탭)을 유저가 원하는 순서로 커스텀할 수 있게 합니다. 서버에 순서 정렬 및 저장 API를 요청할 수 없으므로, 순서를 로컬에 저장하고 불러옵니다. -->

### **배경 (Background)**

<!-- 프로젝트의 Context를 적습니다. 왜 이 기능을 만드는지, 동기는 무엇인지, 어떤 사용자 문제를 해결하려 하는지, 이전에 이런 시도가 있었는지, 있었다면 해결이 되었는지 등을 포함합니다.

> 다양한 탭을 사용하는 유저는 Segment에 따라 하단 탭의 노출 수와 사용 빈도가 다릅니다. 예를 들어, 20대와 30대의 추천 탭 노출 수 사이는 월 n만 정도입니다. 이러한 유저의 Segment에 맞춰 하단 탭 순서를 유저가 직접 커스텀할 수 있다면 뱅크샐러드가 개인화되었다고 인지할 수 있을 것입니다. -->

### **목표 (Goals)**

<!-- 예상 결과들을 Bullet Point 형태로 나열합니다. 이 목표들과 측정 가능한 임팩트들을 이용해 추후 이 프로젝트의 성공 여부를 평가합니다.

> Bottom Navigation의 순서를 유저가 편집할 수 있게 한다.앱을 껐다 켰을 시에도 유저가 편집한 순서대로 하단 탭을 보이게 한다. -->

### **이외 고려 사항들 (Other Considerations)**

<!-- 고려했었으나 하지 않기로 결정된 사항들을 적습니다. 이렇게 함으로써 이전에 논의되었던 주제가 다시 나오지 않도록 할 수 있고, 이미 논의되었던 내용이더라도 리뷰어들이 다시 살펴볼 수 있습니다.

> 앱 데이터 초기화 시에는 사용자가 커스텀했던 리스트를 모두 날리기로 했었으나, 기존 로직에서 앱 데이터 초기화 시에 로컬 관련 추가 핸들링이 없어 이 기능에서도 앱 데이터 초기화 때에 리스트를 날리는 등 추가적인 기능 구현을 하지 않기로 함. -->
